### PR TITLE
Fixed SFTP not working

### DIFF
--- a/image/config/sshd_config
+++ b/image/config/sshd_config
@@ -123,7 +123,7 @@ ChallengeResponseAuthentication no
 #Banner none
 
 # override default of no subsystems
-Subsystem	sftp	/usr/libexec/sftp-server
+Subsystem	sftp	/usr/lib/sftp-server
 
 # Example of overriding settings on a per-user basis
 #Match User anoncvs


### PR DESCRIPTION
sftp-server isn't located under `/usr/libexec/` (the directory doesn't exist). It's instead located at `/usr/lib/sftp-server`
