### PR TITLE
Run initial command before starting services

### DIFF
--- a/image/my_init
+++ b/image/my_init
@@ -18,6 +18,14 @@ def stop_runit(signum, frame):
 	except OSError:
 		pass
 
+# Run initializer command if specified
+if len(sys.argv) > 1:
+	print("*** Running initializer command(s) first...")
+	rv = os.system(' '.join(sys.argv[1:]))
+	if rv != 0:
+		print("!!! Initializer command(s) failed - aborting")
+		sys.exit(rv)
+
 # Start runit.
 signal.signal(signal.SIGCHLD, reap_child)
 print("*** Booting runit...")


### PR DESCRIPTION
This way, any special things specific to a docker images (in my case, initializing the database for redmine) can be done before starting any services.

Any arguments passed will be executed in a subshell. If it fails, the my_init will exit.
