### PR TITLE
Bypass runsvdir-start in order to preserve env

### DIFF
--- a/image/my_init
+++ b/image/my_init
@@ -72,7 +72,7 @@ if is_exe("/etc/rc.local"):
 # Start runit.
 signal.signal(signal.SIGCHLD, reap_child)
 print("*** Booting runit...")
-pid = os.spawnl(os.P_NOWAIT, "/usr/sbin/runsvdir-start", "/usr/sbin/runsvdir-start")
+pid = os.spawnl(os.P_NOWAIT, "/usr/bin/runsvdir", "/usr/bin/runsvdir", "-P", "/etc/service", "log: %s" % ('.' * 395))
 print("*** Runit started as PID %d" % pid)
 signal.signal(signal.SIGTERM, lambda signum, frame: stop_child_process("runit"))
 


### PR DESCRIPTION
runsvdir-start clears the environment, which wipes out any
environment variables passed in when the container starts.
This patch bypasses runsvdir-start and calls runsvdir directly,
preserving the current environment.
