### PR TITLE
Update syslog-ng

### DIFF
--- a/image/runit/syslog-ng
+++ b/image/runit/syslog-ng
@@ -1,3 +1,4 @@
 #!/bin/sh
 set -e
-exec syslog-ng -F -p /var/run/syslog-ng.pid
+mkdir -p /var/lib/syslog-ng
+exec syslog-ng -F --default-modules=affile,afprog,afsocket,afuser,basicfuncs,csvparser,dbparser,syslogformat


### PR DESCRIPTION
In my containers, syslog-ng was failing to start because of afsql being a default, even though it requires an extra package it be installed.  The options were to either install that extra package, or add this argument
