### PR TITLE
Grammar correction in gh-pages index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -205,7 +205,7 @@ CMD ["/my_app/start.sh"]</pre>
         <div class="col-lg-6 col-lg-offset-3">
           <p>Solving <a href="#intro">all the aforementioned problems</a> is a huge pain. I'm sure you have better things to do than to worry about them. That's where <a href="https://github.com/phusion/baseimage-docker">baseimage-docker</a> jumps in.</p>
 
-          <p>Baseimage-docker is a special Docker image that is configured for correct use within Docker containers. It is Ubuntu, plus modifications for Docker-friendliness. Every single of the aforementioned problem is taken care of for you.</p>
+          <p>Baseimage-docker is a special Docker image that is configured for correct use within Docker containers. It is Ubuntu, plus modifications for Docker-friendliness. Every single one of the aforementioned problem's are taken care of for you.</p>
 
           <p>You can use it as a base for your own Docker images. That means it's available for pulling from <a href="https://index.docker.io/u/phusion/baseimage/">the Docker registry</a>!</p>
 


### PR DESCRIPTION
Saw a small error on the github pages, where a sentence didn't quite make sense with a word missing.
