### PR TITLE
--enable-insecure-key install the insecure key at runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,7 +205,30 @@ The following example runs `ls` without running the startup files and with less 
 
 You can use SSH to login to any container that is based on baseimage-docker.
 
-The first thing that you need to do is to ensure that you have the right SSH keys installed inside the container. By default, no keys are installed, so you can't login. For convenience reasons, we provide [a pregenerated, insecure key](https://github.com/phusion/baseimage-docker/blob/master/image/insecure_key) [(PuTTY format)](https://github.com/phusion/baseimage-docker/blob/master/image/insecure_key.ppk) that you easily enable. However, please be aware that using this key is for convenience only. It does not provide any security because this key (both the public and the private side) is publicly available. In production environments, you should use your own keys.
+The first thing that you need to do is to ensure that you have the right SSH keys installed inside the container. By default, no keys are installed, so you can't login. For convenience reasons, we provide [a pregenerated, insecure key](https://github.com/phusion/baseimage-docker/blob/master/image/insecure_key) [(PuTTY format)](https://github.com/phusion/baseimage-docker/blob/master/image/insecure_key.ppk) that you can easily enable. However, please be aware that using this key is for convenience only. It does not provide any security because this key (both the public and the private side) is publicly available. **In production environments, you should use your own keys**.
+
+#### Using the insecure key
+
+Start a container with `--enable-insecure-key`
+
+    docker run YOUR_IMAGE /sbin/my_init --enable-insecure-key
+   
+Find out the ID of the container that you just ran:
+
+    docker ps
+
+Once you have the ID, look for its IP address with:
+
+    docker inspect <ID> | grep IPAddress
+
+Now SSH into the container as follows:
+
+    curl -o insecure_key -fSL https://github.com/phusion/baseimage-docker/raw/master/image/insecure_key
+    chmod 700 insecure_key
+    ssh -i insecure_key root@<IP address>
+
+
+#### Using your own key
 
 Edit your Dockerfile to install an SSH key:
 
@@ -213,15 +236,10 @@ Edit your Dockerfile to install an SSH key:
     ADD your_key /tmp/your_key
     RUN cat /tmp/your_key >> /root/.ssh/authorized_keys && rm -f /tmp/your_key
 
-    ## -OR-
-
-    ## Uncomment this to enable the insecure key.
-    # RUN /usr/sbin/enable_insecure_key
-
 Then rebuild your image. Once you have that, start a container based on that image:
 
     docker run your-image-name
-
+    
 Find out the ID of the container that you just ran:
 
     docker ps
@@ -234,13 +252,6 @@ Now SSH into the container as follows:
 
     ssh -i /path-to/your_key root@<IP address>
 
-    # -OR-
-
-    # If you're using the insecure key, download it and SSH
-    # into the container using that key.
-    curl -o insecure_key -fSL https://github.com/phusion/baseimage-docker/raw/master/image/insecure_key
-    chmod 700 insecure_key
-    ssh -i insecure_key root@<IP address>
 
 <a name="building"></a>
 ## Building the image yourself

--- a/image/enable_insecure_key
+++ b/image/enable_insecure_key
@@ -14,4 +14,17 @@ else
 	echo "Editing $AUTHORIZED_KEYS..."
 	cat /etc/insecure_key.pub >> "$AUTHORIZED_KEYS"
 	echo "Success: insecure key has been added to $AUTHORIZED_KEYS"
+	cat <<-EOF
+
+		+------------------------------------------------------------------------------+
+		| Insecure SSH key installed                                                   |
+		|                                                                              |
+		| DO NOT expose port 22 on the Internet unless you know what you are doing!    |
+		|                                                                              |
+		| Use the private key bellow to connect with user root                         |
+		+------------------------------------------------------------------------------+
+
+	EOF
+	cat /etc/insecure_key
+	echo -e "\n\n"
 fi

--- a/image/my_init
+++ b/image/my_init
@@ -167,7 +167,14 @@ def wait_for_runit_services():
 		if not done:
 			time.sleep(0.1)
 
+def install_insecure_key():
+	info("Installing insecure SSH key for user root")
+	run_command_killable("/usr/sbin/enable_insecure_key")
+
 def main(args):
+	if args.enable_insecure_key:
+		install_insecure_key()
+
 	if not args.skip_startup_files:
 		run_startup_files()
 	
@@ -217,6 +224,9 @@ parser.add_argument('--no-kill-all-on-exit', dest = 'kill_all_on_exit',
 parser.add_argument('--quiet', dest = 'log_level',
 	action = 'store_const', const = LOG_LEVEL_WARN, default = LOG_LEVEL_INFO,
 	help = 'Only print warnings and errors')
+parser.add_argument('--enable-insecure-key', dest = 'enable_insecure_key',
+	action = 'store_const', const = True, default = False,
+	help = 'Install the insecure SSH key')
 args = parser.parse_args()
 log_level = args.log_level
 

--- a/image/system_services.sh
+++ b/image/system_services.sh
@@ -29,8 +29,9 @@ mkdir -p /root/.ssh
 chmod 700 /root/.ssh
 chown root:root /root/.ssh
 cp /build/insecure_key.pub /etc/insecure_key.pub
-chmod 644 /etc/insecure_key.pub
-chown root:root /etc/insecure_key.pub
+cp /build/insecure_key /etc/insecure_key
+chmod 644 /etc/insecure_key*
+chown root:root /etc/insecure_key*
 cp /build/enable_insecure_key /usr/sbin/
 
 ## Install cron daemon.

--- a/test/runner.sh
+++ b/test/runner.sh
@@ -12,19 +12,12 @@ function cleanup()
 	echo " --> Stopping container"
 	docker stop $ID >/dev/null
 	docker rm $ID >/dev/null
-	docker rmi baseimage_test >/dev/null 2>/dev/null
 }
 
 PWD=`pwd`
 
-echo " --> Preparing container"
-ID=`docker run -d $NAME:$VERSION enable_insecure_key`
-docker wait $ID >/dev/null
-docker commit $ID baseimage_test >/dev/null
-docker rm $ID >/dev/null
-
-echo " --> Starting container"
-ID=`docker run -d -v $PWD/test:/test baseimage_test /sbin/my_init`
+echo " --> Starting insecure container"
+ID=`docker run -d -v $PWD/test:/test $NAME:$VERSION /sbin/my_init --enable-insecure-key`
 sleep 1
 
 echo " --> Obtaining IP"


### PR DESCRIPTION
quick usage:

```
docker run YOUR_IMAGE /sbin/my_init --enable-insecure-key
```

close #16
