### PR TITLE
fix log not showing messages sent to stdout by my_init

### DIFF
--- a/image/my_init
+++ b/image/my_init
@@ -1,4 +1,4 @@
-#!/usr/bin/python2
+#!/usr/bin/python2 -u
 import os, sys, stat, signal, errno, argparse, time
 
 KILL_PROCESS_TIMEOUT = 5


### PR DESCRIPTION
**vagrant@baseimage:/vagrant$** `docker images`

```
REPOSITORY          TAG                 IMAGE ID            CREATED             VIRTUAL SIZE
phusion/baseimage   latest              f4e6f8a8ae28        5 days ago          352.8 MB
phusion/baseimage   0.9.6               f4e6f8a8ae28        5 days ago          352.8 MB
ubuntu              12.04               9cd978db300e        2 weeks ago         204.4 MB
```

**vagrant@baseimage:/vagrant$** `docker run -d f4e6f8a8ae28`

```
16636b842da9b4fa7855248d0f833956cfe5ced43781066e4e833649a92d679a
```

**vagrant@baseimage:/vagrant$** `docker logs 16636b842da9`

```
No SSH host key available. Generating one...
debconf: unable to initialize frontend: Dialog
debconf: (TERM is not set, so the dialog frontend is not usable.)
debconf: falling back to frontend: Readline
debconf: unable to initialize frontend: Readline
debconf: (Can't locate Term/ReadLine.pm in @INC (@INC contains: /etc/perl /usr/local/lib/perl/5.14.2 /usr/local/share/perl/5.14.2 /usr/lib/perl5 /usr/share/perl5 /usr/lib/perl/5.14 /usr/share/perl/5.14 /usr/local/lib/site_perl .) at /usr/sh
are/perl5/Debconf/FrontEnd/Readline.pm line 7.)
debconf: falling back to frontend: Teletype
Creating SSH2 RSA key; this may take some time ...
Creating SSH2 DSA key; this may take some time ...
Creating SSH2 ECDSA key; this may take some time ...
```

Where are the log messages from the my_init script ?

**vagrant@baseimage:/vagrant$** `docker attach 16636b842da9`

```
# let's hit <ctrl>-c
?*** Running /etc/my_init.d/00_regen_ssh_host_keys.sh...
*** Running /etc/rc.local...
*** Booting runit daemon...
*** Runit started as PID 83
*** Shutting down runit daemon (PID 83)...
*** Killing all processes...
```

here they are :) a bit late though

That's because by default python script buffers stdout, if we call `my_init` unbuffered we then have:

**vagrant@baseimage:/vagrant$** `docker images`

```
REPOSITORY          TAG                 IMAGE ID            CREATED             VIRTUAL SIZE
phusion/baseimage   unbuff              83deb05827f2        48 seconds ago      423.7 MB
phusion/baseimage   0.9.6               f4e6f8a8ae28        5 days ago          352.8 MB
phusion/baseimage   latest              f4e6f8a8ae28        5 days ago          352.8 MB
ubuntu              12.04               9cd978db300e        2 weeks ago         204.4 MB
```

**vagrant@baseimage:/vagrant$** `docker run -d 83deb05827f2`

```
f0e24d93f8e02a3482f046054599a51673205c72518c42531878b14d23da3ece
```

**vagrant@baseimage:/vagrant$** `docker logs f0e24d93f8e0`

```
*** Running /etc/my_init.d/00_regen_ssh_host_keys.sh...
No SSH host key available. Generating one...
debconf: unable to initialize frontend: Dialog
debconf: (TERM is not set, so the dialog frontend is not usable.)
debconf: falling back to frontend: Readline
debconf: unable to initialize frontend: Readline
debconf: (Can't locate Term/ReadLine.pm in @INC (@INC contains: /etc/perl /usr/local/lib/perl/5.14.2 /usr/local/share/perl/5.14.2 /usr/lib/perl5 /usr/share/perl5 /usr/lib/perl/5.14 /usr/share/perl/5.14 /usr/local/lib/site_perl .) at /usr/sh
are/perl5/Debconf/FrontEnd/Readline.pm line 7.)
debconf: falling back to frontend: Teletype
Creating SSH2 RSA key; this may take some time ...
Creating SSH2 DSA key; this may take some time ...
Creating SSH2 ECDSA key; this may take some time ...
*** Running /etc/rc.local...
*** Booting runit daemon...
*** Runit started as PID 83
```
