### PR TITLE
syslog-ng can fail after a commit

### DIFF
--- a/image/runit/syslog-ng
+++ b/image/runit/syslog-ng
@@ -4,6 +4,7 @@ set -e
 SYSLOGNG_OPTS=""
 
 [ -r /etc/default/syslog-ng ] && . /etc/default/syslog-ng
+[ ! -S /dev/log ] && rm -f /dev/log
 
 case "x$CONSOLE_LOG_LEVEL" in
   x[1-8])


### PR DESCRIPTION
You might be bit by this sooner or later, I started diagnostic here: https://github.com/dotcloud/docker/issues/4336

Come to find out that docker's (go's?) implementation of tar will incorrectly preserve named sockets in committed images as empty files.  This is only a problem for those who commit images that have already been run once, since syslog-ng doesn't clean up after itself.

It works for most, since the dockerfile does not attempt to start syslog-ng during the build.

I propose adding this kind of change to the front of the syslog-ng runit service script (pull attached):

`if [ ! -S /dev/log ]; then rm -f /dev/log; fi`
