### PR TITLE
properly specify location of sftp-server binary

### DIFF
--- a/image/config/sshd_config
+++ b/image/config/sshd_config
@@ -123,7 +123,7 @@ ChallengeResponseAuthentication no
 #Banner none
 
 # override default of no subsystems
-Subsystem	sftp	/usr/lib/sftp-server
+Subsystem	sftp	/usr/lib/openssh/sftp-server
 
 # Example of overriding settings on a per-user basis
 #Match User anoncvs


### PR DESCRIPTION
Currently there is a symlink at /usr/lib/sftp-server to /usr/lib/openssh/sftp-server in the image. That seems to give trouble with packages like the rssh restricted shell, which will not follow a symlink to the sftp server binary for security reasons. So currently it is not possible to use this image as a basis for scp/sftp only access over ssh.
