### PR TITLE
Migrate to Python 3

### DIFF
--- a/image/my_init
+++ b/image/my_init
@@ -1,5 +1,5 @@
-#!/usr/bin/python2 -u
-import os, os.path, sys, stat, signal, errno, argparse, time, json, re, posixfile
+#!/usr/bin/python3 -u
+import os, os.path, sys, stat, signal, errno, argparse, time, json, re
 
 KILL_PROCESS_TIMEOUT = 5
 KILL_ALL_PROCESSES_TIMEOUT = 5


### PR DESCRIPTION
Ubuntu Trusty ships Python 3 by default, but not Python 2. Older versions already ship Python 3, so this change should be safe.
