### PR TITLE
Trim trailing newlines from file-based envs

### DIFF
--- a/image/my_init
+++ b/image/my_init
@@ -59,7 +59,10 @@ def import_envvars(clear_existing_environment = True):
 	for envfile in listdir("/etc/container_environment"):
 		name = os.path.basename(envfile)
 		with open("/etc/container_environment/" + envfile, "r") as f:
-			value = f.read()
+			# Text files often end with a trailing newline, which we
+			# don't want to include in the env variable value. See
+			# https://github.com/phusion/baseimage-docker/pull/49
+			value = re.sub('\n\Z', '', f.read())
 		new_env[name] = value
 	if clear_existing_environment:
 		os.environ.clear()


### PR DESCRIPTION
Many editors add a trailing newline to files. This can result in slightly unexpected values for environment variables read from `/etc/container_environment`.
