### PR TITLE
Use '--rm' instead of '-rm', which was deprecated in Docker 0.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Baseimage-docker *encourages* multiple processes through the use of runit.
 
 To look around in the image, run:
 
-    docker run -rm -t -i phusion/baseimage /sbin/my_init -- bash -l
+    docker run --rm -t -i phusion/baseimage /sbin/my_init -- bash -l
 
 You don't have to download anything manually. The above command will automatically pull the baseimage-docker image from the Docker registry.
 


### PR DESCRIPTION
Just updating the docs to reflect this deprecation.
