### PR TITLE
Meant to fix phusion/baseimage-docker#25

### DIFF
--- a/image/runit/syslog-ng
+++ b/image/runit/syslog-ng
@@ -1,4 +1,6 @@
 #!/bin/sh
+# /dev/log is either a named pipe or it was placed there accidentally
+if [ ! -S /dev/log ]; then rm -f /dev/log; fi
 set -e
 
 SYSLOGNG_OPTS=""


### PR DESCRIPTION
/dev/log can't be a file (it's an error)

Basically takes care of phusion/baseimage-docker#25, phusion/baseimage-docker#31, and phusion/baseimage-docker#59 (seems to work for me, anyway)

Sadly, still no response from upstream on dotcloud/docker#4336
