### PR TITLE
fixed missing parameter for chown in syslog-ng runit script

### DIFF
--- a/image/runit/syslog-ng
+++ b/image/runit/syslog-ng
@@ -24,7 +24,7 @@ esac
 if [ ! -e /dev/xconsole ]
 then
   mknod -m 640 /dev/xconsole p
-  chown root:adm
+  chown root:adm /dev/xconsole
   [ -x /sbin/restorecon ] && /sbin/restorecon $XCONSOLE
 fi
 


### PR DESCRIPTION
There's a missing parameter in syslog-ng's runit script. I noticed this while doing a 'ps'. Not sure whats the impact on the overall container.

```
root        95  0.0  0.0    188    32 ?        S    18:23   0:00 /usr/bin/runsvdir -P /etc/service log: ..........................................................................................................................................................................................................................................................................................................................chown: missing operand after 'root:adm' Try 'chown --help' for more information.
```
