### PR TITLE
my_init --stderr logs to docker, not runit proctitle.

### DIFF
--- a/image/my_init
+++ b/image/my_init
@@ -197,10 +197,12 @@ def run_startup_files():
 		info("Running /etc/rc.local...")
 		run_command_killable_and_import_envvars("/etc/rc.local")
 
-def start_runit():
+def start_runit(stderr):
 	info("Booting runit daemon...")
-	pid = os.spawnl(os.P_NOWAIT, "/usr/bin/runsvdir", "/usr/bin/runsvdir",
-		"-P", "/etc/service", "log: %s" % ('.' * 395))
+	spawn = [os.P_NOWAIT, "/usr/bin/runsvdir", "/usr/bin/runsvdir", "-P", "/etc/service"]
+	if not stderr:
+		spawn.append("log: %s" % ('.' * 395))
+	pid = os.spawnl(*spawn)
 	info("Runit started as PID %d" % pid)
 	return pid
 
@@ -241,7 +243,7 @@ def main(args):
 	exit_code = None
 
 	if not args.skip_runit:
-		runit_pid = start_runit()
+		runit_pid = start_runit(stderr = args.stderr)
 	try:
 		exit_status = None
 		if len(args.main_command) == 0:
@@ -291,6 +293,9 @@ parser.add_argument('--skip-startup-files', dest = 'skip_startup_files',
 parser.add_argument('--skip-runit', dest = 'skip_runit',
 	action = 'store_const', const = True, default = False,
 	help = 'Do not run runit services')
+parser.add_argument('--stderr', dest = 'stderr',
+	action = 'store_const', const = True, default = False,
+	help = 'Log stderr, instead of runit redirecting it to proctitle')
 parser.add_argument('--no-kill-all-on-exit', dest = 'kill_all_on_exit',
 	action = 'store_const', const = False, default = True,
 	help = 'Don\'t kill all processes on the system upon exiting')


### PR DESCRIPTION
As described at http://smarden.org/runit/runsvdir.8.html passing a log option to runsvdir causes stderr to be redirected to the proctitle.  That prevents stderr from reaching docker logs, which is a big problem.

This change adds a `--stderr` argument to my_init, which disables runit's the described proctitle logging, and instead allows stderr to be sent to docker logs as one would expect.

I think should should in fact be the default, but I didn't want to break backwards compatibility for anybody. Perhaps in a future version bump?

I considered `--no-proctitle` rather than `--stderr` but decided the latter is clearer and easier to remember. Feedback welcome.

I've tested running with and without `--stderr`, and confirmed that it causes stderr to be sent to docker logs instead of the proctitle.

Here is the new output of `my_init --help`:

```
usage: my_init [-h] [--enable-insecure-key] [--skip-startup-files]
              [--skip-runit] [--stderr] [--no-kill-all-on-exit] [--quiet]
              [MAIN_COMMAND [MAIN_COMMAND ...]]

Initialize the system.

positional arguments:
 MAIN_COMMAND          The main command to run. (default: runit)

optional arguments:
 -h, --help            show this help message and exit
 --enable-insecure-key
                       Install the insecure SSH key
 --skip-startup-files  Skip running /etc/my_init.d/* and /etc/rc.local
 --skip-runit          Do not run runit services
 --stderr              Log stderr, instead of runit redirecting it to
                       proctitle
 --no-kill-all-on-exit
                       Don't kill all processes on the system upon exiting
 --quiet               Only print warnings and errors
```
