### PR TITLE
my_init: handle OSError from waitpid(-1, 0).

### DIFF
--- a/image/my_init
+++ b/image/my_init
@@ -106,8 +106,11 @@ def waitpid_reap_other_children(pid):
 		else:
 			raise
 	while not done:
-		this_pid, status = os.waitpid(-1, 0)
-		done = this_pid == pid
+		try:
+			this_pid, status = os.waitpid(-1, 0)
+			done = this_pid == pid
+		except OSError as e:
+			done = True
 	return status
 
 def stop_child_process(name, pid, signo = signal.SIGTERM, time_limit = KILL_PROCESS_TIMEOUT):


### PR DESCRIPTION
It's possible for all processes running under my_init to exit and have been reaped before `waitpid_reap_other_children` calls `wait(-1, 0)`.  This is especially likely with `--skip-runit` and a simple process like `true` being run.

Here's an example real-world stack trace:

```
docker run --rm image_name /sbin/my_init --quiet --skip-runit -- true

Traceback (most recent call last):
 File "/sbin/my_init", line 312, in <module>
   main(args)
 File "/sbin/my_init", line 238, in main
   run_startup_files()
 File "/sbin/my_init", line 193, in run_startup_files
   run_command_killable_and_import_envvars(filename)
 File "/sbin/my_init", line 156, in run_command_killable_and_import_envvars
   run_command_killable(*argv)
 File "/sbin/my_init", line 143, in run_command_killable
   status = waitpid_reap_other_children(pid)
 File "/sbin/my_init", line 109, in waitpid_reap_other_children
   this_pid, status = os.waitpid(-1, 0)
OSError: [Errno 10] No child processes
```

Here's the same issue boiled down to a one-liner:

```
$ python -c 'import os; os.waitpid(-1, 0)'
Traceback (most recent call last):
  File "<string>", line 1, in <module>
OSError: [Errno 10] No child processes
```

This patch catches the exception and flags `waitpid_reap_other_children` as done.
