### PR TITLE
Don't write HOME env variable

### DIFF
--- a/image/my_init
+++ b/image/my_init
@@ -74,7 +74,7 @@ def export_envvars(to_dir = True):
 	shell_dump = ""
 	for name, value in os.environ.items():
 		if name in ['HOME', 'USER', 'GROUP', 'UID', 'GID', 'SHELL']:
-			break
+			continue
 		if to_dir:
 			with open("/etc/container_environment/" + name, "w") as f:
 				f.write(value)


### PR DESCRIPTION
Loading HOME variable breaks multi-user container (i.e. logging as postgres user) if you try to load variables via `/etc/container_environment.sh`.
