### PR TITLE
Missing target of chown in syslog-ng runit run file

### DIFF
--- a/image/runit/syslog-ng
+++ b/image/runit/syslog-ng
@@ -24,7 +24,7 @@ esac
 if [ ! -e /dev/xconsole ]
 then
   mknod -m 640 /dev/xconsole p
-  chown root:adm
+  chown root:adm /dev/xconsole
   [ -x /sbin/restorecon ] && /sbin/restorecon $XCONSOLE
 fi
 


### PR DESCRIPTION
I believe this was meant to be /dev/xconsole
