### PR TITLE
needed for insecure key usage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ release: test tag_latest
 	@echo "*** Don't forget to create a tag. git tag rel-$(VERSION) && git push origin rel-$(VERSION)"
 
 ssh:
-	chmod 600 image/insecure_key.pub
+	chmod 600 image/insecure_key
 	@ID=$$(docker ps | grep -F "$(NAME):$(VERSION)" | awk '{ print $$1 }') && \
 		if test "$$ID" = ""; then echo "Container is not running."; exit 1; fi && \
 		IP=$$(docker inspect $$ID | grep IPAddr | sed 's/.*: "//; s/".*//') && \


### PR DESCRIPTION
`chmod 600` is for the benefit of ssh client, which will otherwise spew:

```
chmod 600 image/insecure_key.pub
SSHing into 172.17.0.2
Warning: Permanently added '172.17.0.2' (ECDSA) to the list of known hosts.
@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
@         WARNING: UNPROTECTED PRIVATE KEY FILE!          @
@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
Permissions 0664 for 'image/insecure_key' are too open.
It is required that your private key files are NOT accessible by others.
This private key will be ignored.
bad permissions: ignore key: image/insecure_key
```

As you can see though, the wrong file is `chmod`'ed -- it's the private key which ssh client will insist should be protected with a more restrictive mode.

After this, `CMD ["/sbin/my_init", "--enable-insecure-key"]` and `make ssh` works as expected.
