### PR TITLE
my_init: runsvdir no longer redirects stderr to proctitle.

### DIFF
--- a/image/my_init
+++ b/image/my_init
@@ -219,7 +219,7 @@ def run_startup_files():
 def start_runit():
 	info("Booting runit daemon...")
 	pid = os.spawnl(os.P_NOWAIT, "/usr/bin/runsvdir", "/usr/bin/runsvdir",
-		"-P", "/etc/service", "log: %s" % ('.' * 395))
+		"-P", "/etc/service")
 	info("Runit started as PID %d" % pid)
 	return pid
 


### PR DESCRIPTION
As described at http://smarden.org/runit/runsvdir.8.html passing a log option to runsvdir causes stderr to be redirected to the proctitle.

That prevents stderr from reaching docker logs, which is a big problem.

This is a much simpler alternative to #81 which added more complexity by making this configurable.
@FooBarWidget and myself agreed this should be default; I see no good reason to make it configurable.
