### PR TITLE
remove explicit xauth location

### DIFF
--- a/image/config/sshd_config
+++ b/image/config/sshd_config
@@ -84,8 +84,8 @@ ChallengeResponseAuthentication no
 #GSSAPIStrictAcceptorCheck yes
 #GSSAPIKeyExchange no
 
-# Set this to 'yes' to enable PAM authentication, account processing, 
-# and session processing. If this is enabled, PAM authentication will 
+# Set this to 'yes' to enable PAM authentication, account processing,
+# and session processing. If this is enabled, PAM authentication will
 # be allowed through the ChallengeResponseAuthentication and
 # PasswordAuthentication.  Depending on your PAM configuration,
 # PAM authentication via ChallengeResponseAuthentication may bypass
@@ -101,7 +101,7 @@ ChallengeResponseAuthentication no
 #AllowAgentForwarding yes
 #AllowTcpForwarding yes
 #GatewayPorts no
-#X11Forwarding no
+X11Forwarding yes
 #X11DisplayOffset 10
 #X11UseLocalhost yes
 #PrintMotd yes
@@ -130,6 +130,3 @@ Subsystem	sftp	/usr/lib/openssh/sftp-server
 #	X11Forwarding no
 #	AllowTcpForwarding no
 #	ForceCommand cvs server
-
-# XAuthLocation added by XQuartz (http://xquartz.macosforge.org)
-XAuthLocation /opt/X11/bin/xauth


### PR DESCRIPTION
Change allows to connect by ssh using X11 forwarding from linux host, otherwise you get
debug1: Remote: No xauth program; cannot forward with spoofing.
