### PR TITLE
Create mountpoint for Vagrant synced folder

### DIFF
--- a/image/Dockerfile
+++ b/image/Dockerfile
@@ -10,4 +10,7 @@ RUN /build/prepare.sh && \
 	/build/utilities.sh && \
 	/build/cleanup.sh
 
+# Create mountpoint for Vagrant synced folder
+RUN mkdir -p /vagrant
+
 CMD ["/sbin/my_init"]


### PR DESCRIPTION
This small fix allows the image to be used from the Vagrant Docker provider

See http://docs.vagrantup.com/v2/docker/

As an example of use please see https://github.com/gmacario/vagrant-ubuntu1404

Signed-off-by: Gianpaolo Macario <gmacario@gmail.com>