### PR TITLE
Remove Dockerfile step for mkdir /build

### DIFF
--- a/image/Dockerfile
+++ b/image/Dockerfile
@@ -2,7 +2,6 @@ FROM ubuntu:14.04
 MAINTAINER Phusion <info@phusion.nl>
 
 ENV HOME /root
-RUN mkdir /build
 ADD . /build
 
 RUN /build/prepare.sh && \


### PR DESCRIPTION
The ADD command will create /build automatically, so the RUN mkdir step can be safely removed. Also, this has the benefit of reducing the number of steps in the Dockerfile which is helpful for not as quickly hitting the 127 layer limit.