### PR TITLE
docker-bash now supports high value PID

### DIFF
--- a/tools/docker-bash
+++ b/tools/docker-bash
@@ -20,7 +20,7 @@ fi
 CONTAINER_ID="$1"
 shift
 
-PID=`docker inspect -f "{{ .State.Pid }}" "$CONTAINER_ID"`
+PID=`docker inspect -f "{{ .State.Pid }}" "$CONTAINER_ID" | awk '{ print sprintf("%.f", $1); }'`
 if test $# = 0; then
 	exec "$SELFDIR/baseimage-docker-nsenter" --target "$PID" --mount --uts --ipc --net --pid -- /bin/bash -l
 else


### PR DESCRIPTION
Convert the output of 'docker inspect -f {{ .State.Pid}}' to decimal notation and then round to the nearest integer for tools/docker-bash
Closes #170 