### PR TITLE
fixed system_services.sh

### DIFF
--- a/image/Dockerfile
+++ b/image/Dockerfile
@@ -1,4 +1,4 @@
-FROM armv7/ubuntu_core:14.04
+FROM armv7/armhf-ubuntu_core:14.10
 MAINTAINER Phusion <info@phusion.nl>
 
 ENV HOME /root

--- a/image/Dockerfile
+++ b/image/Dockerfile
@@ -1,5 +1,5 @@
-FROM armv7/ubuntu_core:14.10
-MAINTAINER Uli Middelberg <armv7@midelberg.de>
+FROM armv7/ubuntu_core:14.04
+MAINTAINER Phusion <info@phusion.nl>
 
 ENV HOME /root
 ENV DEBIAN_FRONTEND noninteractive

--- a/image/Dockerfile
+++ b/image/Dockerfile
@@ -1,7 +1,9 @@
-FROM ubuntu:14.04
-MAINTAINER Phusion <info@phusion.nl>
+FROM armv7/ubuntu_core:14.10
+MAINTAINER Uli Middelberg <armv7@midelberg.de>
 
 ENV HOME /root
+ENV DEBIAN_FRONTEND noninteractive
+
 RUN mkdir /build
 ADD . /build
 

--- a/image/system_services.sh
+++ b/image/system_services.sh
@@ -20,7 +20,7 @@ ln -s /etc/container_environment.sh /etc/profile.d/
 $minimal_apt_get_install runit
 
 ## Install a syslog daemon.
-$minimal_apt_get_install syslog-ng-core
+RUNLEVEL=1 $minimal_apt_get_install syslog-ng-core
 mkdir /etc/service/syslog-ng
 cp /build/runit/syslog-ng /etc/service/syslog-ng/run
 mkdir -p /var/lib/syslog-ng
@@ -34,8 +34,8 @@ $minimal_apt_get_install logrotate
 
 ## Install the SSH server.
 $minimal_apt_get_install openssh-server
-mkdir /var/run/sshd
-mkdir /etc/service/sshd
+mkdir -p /var/run/sshd
+mkdir -p /etc/service/sshd
 cp /build/runit/sshd /etc/service/sshd/run
 cp /build/config/sshd_config /etc/ssh/sshd_config
 cp /build/00_regen_ssh_host_keys.sh /etc/my_init.d/


### PR DESCRIPTION
I needed to change `system_services.sh` in order to run 

    docker build image

successfully. The installation of `syslog-ng` failed because `apt-get install` will try to start the `syslog-ng` service before `system_services.sh` has the chance to modify the `syslog-ng` configuration.
Running `RUNLEVEL=1 apt-get install ...` will prevent this.

    
