### PR TITLE
Preserve /build/{cleanup.sh,buildconfig} files.

### DIFF
--- a/image/cleanup.sh
+++ b/image/cleanup.sh
@@ -4,7 +4,7 @@ source /bd_build/buildconfig
 set -x
 
 apt-get clean
-rm -rf /bd_build
+ls -d -1 /bd_build/**/* | grep -v "cleanup.sh" | grep -v "buildconfig" | xargs rm -f
 rm -rf /tmp/* /var/tmp/*
 rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
`/build/{cleanup.sh,buildconfig}` files are useful for those who create Docker images based on this
baseimage, and need to make a final cleanup and/or use some
configurations that are inside `buildconfig` file.
