### PR TITLE
replace insecure-key support with authorized-key support

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,8 @@
+## -bukzor0 (not planned for release)
+
+ * removed insecure-key support
+ * added authorized-keys support
+
 ## 0.9.16 (release date: 2015-01-20)
 
  * `docker exec` is now the default and recommended mechanism for running commands in the container. SSH is now disabled by default, but is still supported for those cases where "docker exec" is not appropriate. Closes GH-168.

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 NAME = phusion/baseimage
-VERSION = 0.9.16
+VERSION = 0.9.16-bukzor0
 
 .PHONY: all build test tag_latest release ssh
 
@@ -8,7 +8,7 @@ all: build
 build:
 	docker build -t $(NAME):$(VERSION) --rm image
 
-test:
+test: build
 	env NAME=$(NAME) VERSION=$(VERSION) ./test/runner.sh
 
 tag_latest:
@@ -21,9 +21,6 @@ release: test tag_latest
 	@echo "*** Don't forget to create a tag. git tag rel-$(VERSION) && git push origin rel-$(VERSION)"
 
 ssh:
-	chmod 600 image/insecure_key
 	@ID=$$(docker ps | grep -F "$(NAME):$(VERSION)" | awk '{ print $$1 }') && \
 		if test "$$ID" = ""; then echo "Container is not running."; exit 1; fi && \
-		IP=$$(docker inspect $$ID | grep IPAddr | sed 's/.*: "//; s/".*//') && \
-		echo "SSHing into $$IP" && \
-		ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -i image/insecure_key root@$$IP
+		./tools/docker-ssh $$ID

--- a/image/00_regen_ssh_host_keys.sh
+++ b/image/00_regen_ssh_host_keys.sh
@@ -1,8 +1,0 @@
-#!/bin/bash
-set -e
-if [[ ! -e /etc/service/sshd/down && ! -e /etc/ssh/ssh_host_rsa_key ]] || [[ "$1" == "-f" ]]; then
-	echo "No SSH host key available. Generating one..."
-	export LC_ALL=C
-	export DEBIAN_FRONTEND=noninteractive
-	dpkg-reconfigure openssh-server
-fi

--- a/image/bin/my_init
+++ b/image/bin/my_init
@@ -244,16 +244,9 @@ def wait_for_runit_services():
 		if not done:
 			time.sleep(0.1)
 
-def install_insecure_key():
-	info("Installing insecure SSH key for user root")
-	run_command_killable("/usr/sbin/enable_insecure_key")
-
 def main(args):
 	import_envvars(False, False)
 	export_envvars()
-
-	if args.enable_insecure_key:
-		install_insecure_key()
 
 	if not args.skip_startup_files:
 		run_startup_files()
@@ -304,9 +297,6 @@ def main(args):
 parser = argparse.ArgumentParser(description = 'Initialize the system.')
 parser.add_argument('main_command', metavar = 'MAIN_COMMAND', type = str, nargs = '*',
 	help = 'The main command to run. (default: runit)')
-parser.add_argument('--enable-insecure-key', dest = 'enable_insecure_key',
-	action = 'store_const', const = True, default = False,
-	help = 'Install the insecure SSH key')
 parser.add_argument('--skip-startup-files', dest = 'skip_startup_files',
 	action = 'store_const', const = True, default = False,
 	help = 'Skip running /etc/my_init.d/* and /etc/rc.local')

--- a/image/runit/sshd
+++ b/image/runit/sshd
@@ -1,3 +1,29 @@
-#!/bin/sh
+#!/bin/bash
 set -e
+
+if [[ ! -e /etc/ssh/ssh_host_rsa_key ]]; then
+	echo "No SSH host key available. Generating one..."
+	export LC_ALL=C
+	export DEBIAN_FRONTEND=noninteractive
+	dpkg-reconfigure openssh-server
+fi
+
+if [ -n "${AUTHORIZED_KEYS}" -a "${AUTHORIZED_KEYS}" != "**None**" ]; then
+	echo "Found authorized keys"
+	mkdir -p /root/.ssh
+	chmod 755 /root/.ssh
+	touch /root/.ssh/authorized_keys
+	chmod 644 /root/.ssh/authorized_keys
+	# keys can be comma- or newline-delimited
+	IFS=$'\n'
+	keys=$(echo "${AUTHORIZED_KEYS}" | tr "," "\n")
+	for key in $keys; do
+		key=$(echo "$key" |sed -e 's/^ *//' -e 's/ *$//')
+		if ! grep -q "$key" /root/.ssh/authorized_keys; then
+			echo "Adding public key to /root/.ssh/authorized_keys: $key"
+			echo "$key" >> /root/.ssh/authorized_keys
+		fi
+	done
+fi
+
 exec /usr/sbin/sshd -D

--- a/image/system_services.sh
+++ b/image/system_services.sh
@@ -46,17 +46,6 @@ mkdir /etc/service/sshd
 touch /etc/service/sshd/down
 cp /build/runit/sshd /etc/service/sshd/run
 cp /build/config/sshd_config /etc/ssh/sshd_config
-cp /build/00_regen_ssh_host_keys.sh /etc/my_init.d/
-
-## Install default SSH key for root and app.
-mkdir -p /root/.ssh
-chmod 700 /root/.ssh
-chown root:root /root/.ssh
-cp /build/insecure_key.pub /etc/insecure_key.pub
-cp /build/insecure_key /etc/insecure_key
-chmod 644 /etc/insecure_key*
-chown root:root /etc/insecure_key*
-cp /build/bin/enable_insecure_key /usr/sbin/
 
 ## Install cron daemon.
 $minimal_apt_get_install cron

--- a/test/runner.sh
+++ b/test/runner.sh
@@ -17,11 +17,11 @@ function cleanup()
 PWD=`pwd`
 
 echo " --> Starting insecure container"
-ID=`docker run -d -v $PWD/test:/test $NAME:$VERSION /sbin/my_init --enable-insecure-key`
+ID=`docker run --env=AUTHORIZED_KEYS="$(ssh-add -L)" -d -v $PWD/test:/test $NAME:$VERSION`
 sleep 1
 
 echo " --> Obtaining IP"
-IP=`docker inspect $ID | grep IPAddress | sed -e 's/.*: "//; s/".*//'`
+IP=`docker inspect --format='{{ .NetworkSettings.IPAddress }}' $ID`
 if [[ "$IP" = "" ]]; then
 	abort "Unable to obtain container IP"
 fi
@@ -29,14 +29,10 @@ fi
 trap cleanup EXIT
 
 echo " --> Enabling SSH in the container"
-docker exec -t -i $ID /etc/my_init.d/00_regen_ssh_host_keys.sh -f
-docker exec -t -i $ID rm /etc/service/sshd/down
-docker exec -t -i $ID sv start /etc/service/sshd
+docker exec $ID sv start /etc/service/sshd
 sleep 1
 
 echo " --> Logging into container and running tests"
-cp image/insecure_key /tmp/insecure_key
-chmod 600 /tmp/insecure_key
 sleep 1 # Give container some more time to start up.
-ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -i /tmp/insecure_key root@$IP \
+ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no root@$IP \
 	/bin/bash /test/test.sh

--- a/test/test.sh
+++ b/test/test.sh
@@ -8,15 +8,19 @@ function ok()
 
 function fail()
 {
-	echo "  FAIL"
+	echo "  FAIL ($1)"
 	exit 1
 }
 
 echo "Checking whether all services are running..."
-services=`sv status /etc/service/*`
+services=$(echo /etc/service/* | xargs sv check)
 status=$?
-if [[ "$status" != 0 || "$services" = "" || "$services" =~ down ]]; then
-	fail
+if [[ "$status" != 0 ]]; then
+	fail "status $status"
+elif [[ "$services" = "" ]]; then
+	fail "no output"
+elif echo "$services" | grep -v '^ok: run: /etc/service/' | grep . ; then
+	fail "service down"
 else
 	ok
 fi

--- a/tools/docker-ssh
+++ b/tools/docker-ssh
@@ -1,7 +1,6 @@
 #!/bin/sh
 set -e
 
-KNOWN_HOSTS_FILE=
 IP=
 
 usage()
@@ -18,10 +17,6 @@ cleanup()
 	if test "$pids" != ""; then
 		kill $pids
 	fi
-
-	if test "$KNOWN_HOSTS_FILE" != ""; then
-		rm -f "$KNOWN_HOSTS_FILE"
-	fi
 }
 
 if test $# = 0; then
@@ -34,48 +29,26 @@ shift
 
 trap cleanup EXIT
 
-if ! test -e ~/.baseimage_docker_insecure_key; then
-	if test -e /usr/local/share/baseimage-docker/insecure_key; then
-		cp /usr/local/share/baseimage-docker/insecure_key ~/.baseimage_docker_insecure_key
-	else
-		dir=`dirname "$0"`
-		dir=`cd "$dir/.." && pwd`
-		if test -e "$dir/image/insecure_key"; then
-			cp "$dir/image/insecure_key" ~/.baseimage_docker_insecure_key
-		else
-			echo "*** ERROR ***: Baseimage-docker insecure key not found." >&2
-			echo "You probably didn't install docker-ssh properly. Please reinstall it:" >&2
-			echo "" >&2
-			echo "  curl --fail -L -O https://github.com/phusion/baseimage-docker/archive/master.tar.gz && \\" >&2
-			echo "  tar xzf master.tar.gz && \\" >&2
-			echo "  sudo ./baseimage-docker-master/install-tools.sh" >&2
-			exit 1
-		fi
-	fi
-	chown "`whoami`": ~/.baseimage_docker_insecure_key
-	chmod 600 ~/.baseimage_docker_insecure_key
-fi
-
-KNOWN_HOSTS_FILE=`mktemp /tmp/docker-ssh.XXXXXXXXX`
 IP=`docker inspect -f "{{ .NetworkSettings.IPAddress }}" "$CONTAINER_ID"`
 
-# Prevent SSH from warning about adding a host to the known_hosts file.
-ssh-keyscan "$IP" >"$KNOWN_HOSTS_FILE" 2>&1
-
-if ! ssh -i ~/.baseimage_docker_insecure_key \
-	-o UserKnownHostsFile="$KNOWN_HOSTS_FILE" \
+if ! ssh \
+	-o LogLevel=ERROR \
+	-o GlobalKnownHostsFile=/dev/null \
+	-o UserKnownHostsFile=/dev/null \
 	-o StrictHostKeyChecking=no \
-	-o PasswordAuthentication=no \
-	-o KbdInteractiveAuthentication=no \
-	-o ChallengeResponseAuthentication=no \
+	-o BatchMode=yes \
+	-o ConnectTimeout=3 \
 	"root@$IP" "$@"
 then
 	STATUS=$?
 	if test $# = 0; then
 		echo "----------------"
 		echo "It appears that login to the Docker container failed. This could be caused by the following reasons:"
+		## TODO: we can automatically detect which is the problem, provide a better error message.
 		echo "- The Docker container you're trying to login to is not based on Baseimage-docker. The docker-ssh tool only works with Baseimage-docker-based containers."
-		echo "- You did not enable the the insecure key inside the container. Please read https://github.com/phusion/baseimage-docker/blob/master/README.md#login to learn how to enable the insecure key."
+                echo "- You have no ssh-agent connection, or no keys added (to check, run: ssh-add -L)"
+		echo '- You did not start the image with any authorized keys (--env=AUTHORIZED_KEYS="$(ssh-add -L)")'
+		echo "- The image's sshd service is not started. Please read https://github.com/phusion/baseimage-docker/blob/master/README.md#login to learn how to enable the sshd service."
 	fi
 	exit $STATUS
 fi


### PR DESCRIPTION
I think this fills all the use cases of the insecure-key, plus some, and is overall more secure.
