### PR TITLE
Added suport for ARMv7

### DIFF
--- a/image/Dockerfile.armv7
+++ b/image/Dockerfile.armv7
@@ -1,4 +1,4 @@
-FROM armv7/armhf-ubuntu_core:14.04
+FROM armv7/armhf-ubuntu:14.04
 MAINTAINER Phusion <info@phusion.nl>
 
 ENV HOME /root

--- a/image/Dockerfile.armv7
+++ b/image/Dockerfile.armv7
@@ -1,0 +1,12 @@
+FROM armv7/armhf-ubuntu_core:14.04
+MAINTAINER Phusion <info@phusion.nl>
+
+ENV HOME /root
+ADD . /build
+
+RUN /build/prepare.sh && \
+	/build/system_services.sh && \
+	/build/utilities.sh && \
+	/build/cleanup.sh
+
+CMD ["/sbin/my_init"]

--- a/image/system_services.sh
+++ b/image/system_services.sh
@@ -20,7 +20,7 @@ ln -s /etc/container_environment.sh /etc/profile.d/
 $minimal_apt_get_install runit
 
 ## Install a syslog daemon.
-$minimal_apt_get_install syslog-ng-core
+RUNLEVEL=1 $minimal_apt_get_install syslog-ng-core
 mkdir /etc/service/syslog-ng
 cp /build/runit/syslog-ng /etc/service/syslog-ng/run
 mkdir -p /var/lib/syslog-ng
@@ -41,8 +41,8 @@ cp /build/config/logrotate_syslogng /etc/logrotate.d/syslog-ng
 
 ## Install the SSH server.
 $minimal_apt_get_install openssh-server
-mkdir /var/run/sshd
-mkdir /etc/service/sshd
+mkdir -p /var/run/sshd
+mkdir -p /etc/service/sshd
 touch /etc/service/sshd/down
 cp /build/runit/sshd /etc/service/sshd/run
 cp /build/config/sshd_config /etc/ssh/sshd_config


### PR DESCRIPTION
The changes in `image/system_services.sh` are not armv7 specific and shouldn't cause any harm on other ubuntu platforms. `image/Dockerfile.armv7` is a slightly modified version of `image/Dockerfile`

The recent docker version allows to specify an alternative Dokerfile for building, like:

    sudo docker build -t armhf-baseimage-docker -f image/Dockerfile.armv7 image
 
 