### PR TITLE
syslog-forwarder continue after logrotate

### DIFF
--- a/image/runit/syslog-forwarder
+++ b/image/runit/syslog-forwarder
@@ -1,2 +1,2 @@
 #!/bin/sh
-exec tail -f -n 0 /var/log/syslog
+exec tail -F -n 0 /var/log/syslog


### PR DESCRIPTION
logrotate configured by this image has `delaycompress` and `daily` on `/var/log/syslog`. Which means, that upon logrotate, `/var/log/syslog` is renamed to `syslog.1` (this is the file being tailed by forwarder). New `/var/log/syslog` is forwarded no more. (dramatic music)