### PR TITLE
Use COPY instead of ADD

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ In `memcached.sh` (make sure this file is chmod +x):
 In `Dockerfile`:
 
     RUN mkdir /etc/service/memcached
-    ADD memcached.sh /etc/service/memcached/run
+    COPY memcached.sh /etc/service/memcached/run
 
 Note that the shell script must run the daemon **without letting it daemonize/fork it**. Usually, daemons provide a command line flag or a config file option for that.
 
@@ -191,7 +191,7 @@ In `logtime.sh` (make sure this file is chmod +x):
 In `Dockerfile`:
 
     RUN mkdir -p /etc/my_init.d
-    ADD logtime.sh /etc/my_init.d/logtime.sh
+    COPY logtime.sh /etc/my_init.d/logtime.sh
 
 <a name="environment_variables"></a>
 ### Environment variables
@@ -456,7 +456,7 @@ Instructions for logging in the container is the same as in section [Using the i
 Edit your Dockerfile to install an SSH public key:
 
     ## Install an SSH of your choice.
-    ADD your_key.pub /tmp/your_key.pub
+    COPY your_key.pub /tmp/your_key.pub
     RUN cat /tmp/your_key.pub >> /root/.ssh/authorized_keys && rm -f /tmp/your_key.pub
 
 Then rebuild your image. Once you have that, start a container based on that image:

--- a/README_ZH_cn_.md
+++ b/README_ZH_cn_.md
@@ -156,7 +156,7 @@ The image is called `phusion/baseimage`, and is available on the Docker registry
 	
 	### 在Dockerfile中:
     RUN mkdir /etc/service/memcached
-    ADD memcached.sh /etc/service/memcached/run
+    COPY memcached.sh /etc/service/memcached/run
 
 注意脚本必须运行在后台的,**不能让他们进程进行daemonize/fork**.通常,后台进程会提供一个标志位或者配置文件.
 
@@ -178,7 +178,7 @@ baseimage-docker的初始化脚本 `/sbin/my_init`,在启动的时候进程运�
 
     ### 在 Dockerfile中:
     RUN mkdir -p /etc/my_init.d
-    ADD logtime.sh /etc/my_init.d/logtime.sh
+    COPY logtime.sh /etc/my_init.d/logtime.sh
 
 
 <a name="environment_variables"></a>
@@ -487,7 +487,7 @@ Baseimage-docker提供了一个灵活的方式运行只要一闪而过的命令,
 编辑你的dockerfile,来安装ssh public key:
 
     ## 安装你自己的public key.
-    ADD your_key.pub /tmp/your_key.pub
+    COPY your_key.pub /tmp/your_key.pub
     RUN cat /tmp/your_key.pub >> /root/.ssh/authorized_keys && rm -f /tmp/your_key.pub
 
 重新创建你的镜像.一旦你创建成功,启动基于这个镜像的容器.

--- a/README_zh_tw.md
+++ b/README_zh_tw.md
@@ -156,7 +156,7 @@ The image is called `phusion/baseimage`, and is available on the Docker registry
 	
 	### 在Dockerfile中:
     RUN mkdir /etc/service/memcached
-    ADD memcached.sh /etc/service/memcached/run
+    COPY memcached.sh /etc/service/memcached/run
 
 注意腳本必須運行在後臺的,**不能讓他們行程進行daemonize/fork**.通常,後臺行程會提供一個標誌位或者配置文件.
 
@@ -178,7 +178,7 @@ baseimage-docker的初始化腳本 `/sbin/my_init`,在啓動的時候行程運�
 
     ### 在 Dockerfile中:
     RUN mkdir -p /etc/my_init.d
-    ADD logtime.sh /etc/my_init.d/logtime.sh
+    COPY logtime.sh /etc/my_init.d/logtime.sh
 
 
 <a name="environment_variables"></a>
@@ -487,7 +487,7 @@ Baseimage-docker提供了一個靈活的方式運行只要一閃而過的命令,
 編輯你的dockerfile,來安裝ssh public key:
 
     ## 安裝你自己的public key.
-    ADD your_key.pub /tmp/your_key.pub
+    COPY your_key.pub /tmp/your_key.pub
     RUN cat /tmp/your_key.pub >> /root/.ssh/authorized_keys && rm -f /tmp/your_key.pub
 
 重新創建你的鏡像.一旦你創建成功,啓動基於這個鏡像的容器.

--- a/image/Dockerfile
+++ b/image/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:14.04
 MAINTAINER Phusion <info@phusion.nl>
 
-ADD . /bd_build
+COPY . /bd_build
 
 RUN /bd_build/prepare.sh && \
 	/bd_build/system_services.sh && \


### PR DESCRIPTION
While COPY and ADD are essentially interchangeable here, it is still
considered good practice to use COPY whenever possible. From the docker
docks on best practices:

```
"Although ADD and COPY are functionally similar, generally speaking,
COPY is preferred. That’s because it’s more transparent than ADD.
[...] For other items (files, directories) that do not require ADD’s tar
auto-extraction capability, you should always use COPY."
```

Additionally, ADD commands were not cached prior to 0.7.3 (which was
released on 2013-01-02).
