### PR TITLE
Fixed bug introduced in PR-182

### DIFF
--- a/image/system_services.sh
+++ b/image/system_services.sh
@@ -20,10 +20,10 @@ ln -s /etc/container_environment.sh /etc/profile.d/
 $minimal_apt_get_install runit
 
 ## Install a syslog daemon and logrotate.
-[ "$DISABLE_SYSLOG" -eq 0 ] && /bd_build/services/syslog-ng/syslog-ng.sh
+[ "$DISABLE_SYSLOG" -eq 0 ] && /bd_build/services/syslog-ng/syslog-ng.sh || true
 
 ## Install the SSH server.
-[ "$DISABLE_SSH" -eq 0 ] && /bd_build/services/sshd/sshd.sh
+[ "$DISABLE_SSH" -eq 0 ] && /bd_build/services/sshd/sshd.sh || true
 
 ## Install cron daemon.
-[ "$DISABLE_CRON" -eq 0 ] && /bd_build/services/cron/cron.sh
+[ "$DISABLE_CRON" -eq 0 ] && /bd_build/services/cron/cron.sh || true


### PR DESCRIPTION
If you disable the installation of all services, you could have a != 0
output, and break the `docker build` process.