### PR TITLE
fix test for Docker 1.9.1

### DIFF
--- a/test/runner.sh
+++ b/test/runner.sh
@@ -21,7 +21,7 @@ ID=`docker run -d -v $PWD/test:/test $NAME:$VERSION /sbin/my_init --enable-insec
 sleep 1
 
 echo " --> Obtaining IP"
-IP=`docker inspect $ID | grep IPAddress | sed -e 's/.*: "//; s/".*//'`
+IP=`docker inspect --format '{{ .NetworkSettings.IPAddress }}' $ID`
 if [[ "$IP" = "" ]]; then
 	abort "Unable to obtain container IP"
 fi


### PR DESCRIPTION
With Docker 1.9, grepping for "IPAddress" does not work as expected. Using --format instead fixes that.