### PR TITLE
Remove correct apt-speedup file in cleanup.sh

### DIFF
--- a/image/cleanup.sh
+++ b/image/cleanup.sh
@@ -7,6 +7,6 @@ apt-get clean
 rm -rf /bd_build
 rm -rf /tmp/* /var/tmp/*
 rm -rf /var/lib/apt/lists/*
-rm -f /etc/dpkg/dpkg.cfg.d/02apt-speedup
+rm -f /etc/dpkg/dpkg.cfg.d/docker-apt-speedup
 
 rm -f /etc/ssh/ssh_host_*


### PR DESCRIPTION
The temporary file for apt speedup was renamed in 8f2877c806186511611017395d6f87cd00392adf but not updated in `/image/cleanup.sh`.

It's a bit unclear to me if the speedup fix should remain after building the image (and if it's enabled by default in the Ubuntu image, as mentioned in the 8f2877c806186511611017395d6f87cd00392adf commit comment). If the current behavior is intentional, and the current build basically replaces `/etc/dpkg/dpkg.cfg.d/02apt-speedup` with `/etc/dpkg/dpkg.cfg.d/docker-apt-speedup`, it should probably be documented in the cleanup script, and not be described as *temporary* in https://github.com/phusion/baseimage-docker/blob/master/image/prepare.sh#L6.