### PR TITLE
Add argument --ssh-port to my_init

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-NAME = phusion/baseimage
+NAME = sigmas/baseimage
 VERSION = 0.9.18
 
 .PHONY: all build test tag_latest release ssh

--- a/image/Dockerfile
+++ b/image/Dockerfile
@@ -1,5 +1,5 @@
 FROM ubuntu:14.04
-MAINTAINER Phusion <info@phusion.nl>
+MAINTAINER Huang Hao <huanghao@yy.com>
 
 ADD . /bd_build
 

--- a/image/bin/my_init
+++ b/image/bin/my_init
@@ -1,5 +1,5 @@
 #!/usr/bin/python3 -u
-import os, os.path, sys, stat, signal, errno, argparse, time, json, re
+import os, os.path, sys, stat, signal, errno, argparse, time, json, re, fileinput
 
 KILL_PROCESS_TIMEOUT = 5
 KILL_ALL_PROCESSES_TIMEOUT = 5
@@ -260,16 +260,25 @@ def install_insecure_key():
 	info("Installing insecure SSH key for user root")
 	run_command_killable("/usr/sbin/enable_insecure_key")
 
+def change_sshd_config(port):
+	with fileinput.input(files=("/etc/ssh/sshd_config",), inplace=True) as f:
+		for line in f:
+			line = re.sub(r"^#?Port\s.*", r"Port {}".format(port), line)
+			sys.stdout.write(line)
+
 def main(args):
 	import_envvars(False, False)
 	export_envvars()
+
+	if args.ssh_port > 0:
+		change_sshd_config(args.ssh_port)
 
 	if args.enable_insecure_key:
 		install_insecure_key()
 
 	if not args.skip_startup_files:
 		run_startup_files()
-	
+
 	runit_exited = False
 	exit_code = None
 
@@ -331,6 +340,9 @@ parser.add_argument('--no-kill-all-on-exit', dest = 'kill_all_on_exit',
 parser.add_argument('--quiet', dest = 'log_level',
 	action = 'store_const', const = LOG_LEVEL_WARN, default = LOG_LEVEL_INFO,
 	help = 'Only print warnings and errors')
+parser.add_argument('--ssh-port', dest = 'ssh_port',
+	action = 'store', type = int, default = 22,
+	help = 'Specifies the port on which the ssh server listens for connections')
 args = parser.parse_args()
 log_level = args.log_level
 

--- a/image/utilities.sh
+++ b/image/utilities.sh
@@ -15,6 +15,7 @@ rm -f /sbin/init /sbin/telinit /sbin/reboot /sbin/shutdown
 cat > /sbin/reboot << EOF
 #!/bin/sh
 # This file is intentionally changed by huanghao@yy.com
+/bin/echo -e "\n*** reboot was called from inside container" >> /dev/termination-log
 /bin/kill 1
 EOF
 ln -s /sbin/reboot /sbin/shutdown

--- a/image/utilities.sh
+++ b/image/utilities.sh
@@ -4,7 +4,7 @@ source /bd_build/buildconfig
 set -x
 
 ## Often used tools.
-$minimal_apt_get_install curl less vim-tiny psmisc
+$minimal_apt_get_install curl less vim-tiny psmisc lsof tree traceroute python
 ln -s /usr/bin/vim.tiny /usr/bin/vim
 
 ## This tool runs a command as another user and sets $HOME.
@@ -15,7 +15,7 @@ rm -f /sbin/init /sbin/telinit /sbin/reboot /sbin/shutdown
 cat > /sbin/reboot << EOF
 #!/bin/sh
 # This file is intentionally changed by huanghao@yy.com
-/bin/echo -e "\n*** reboot was called from inside container" >> /dev/termination-log
+/bin/echo -n "Reboot was called from inside container" > /dev/termination-log
 /bin/kill 1
 EOF
 ln -s /sbin/reboot /sbin/shutdown

--- a/image/utilities.sh
+++ b/image/utilities.sh
@@ -9,3 +9,19 @@ ln -s /usr/bin/vim.tiny /usr/bin/vim
 
 ## This tool runs a command as another user and sets $HOME.
 cp /bd_build/bin/setuser /sbin/setuser
+
+## Replace dangerous upstart commands
+rm -f /sbin/init /sbin/telinit /sbin/reboot /sbin/shutdown
+cat > /sbin/reboot << EOF
+#!/bin/sh
+# This file is intentionally changed by huanghao@yy.com
+/bin/kill 1
+EOF
+ln -s /sbin/reboot /sbin/shutdown
+cat > /sbin/init << EOF
+#!/bin/sh
+# This file is intentionally changed by huanghao@yy.com
+>&2 echo init is disabled intentionally.
+EOF
+ln -s /sbin/init /sbin/telinit
+chmod +x /sbin/init /sbin/telinit /sbin/reboot /sbin/shutdown


### PR DESCRIPTION
Hi, 

My deployment needs to start several baseimage docker instances on the same physical host. But there is no way to specify the ssh listening port in a flexible way. That's why I add the argument `--ssh-port` to `my_init`, so that the ssh server port can be changed before running the image. 

Usage:

    docker run YOUR_IMAGE /sbin/my_init --ssh-port=SOME_PORT

* The default port is 22.
* SSH still needs to be enabled first.

