### PR TITLE
configure process kill timeouts through environment with fallbacks

### DIFF
--- a/image/bin/my_init
+++ b/image/bin/my_init
@@ -1,8 +1,8 @@
 #!/usr/bin/python3 -u
 import os, os.path, sys, stat, signal, errno, argparse, time, json, re
 
-KILL_PROCESS_TIMEOUT = 5
-KILL_ALL_PROCESSES_TIMEOUT = 5
+KILL_PROCESS_TIMEOUT = 5 if not os.environ.get('KILL_PROCESS_TIMEOUT') else os.environ.get('KILL_PROCESS_TIMEOUT')
+KILL_ALL_PROCESSES_TIMEOUT = 5 if not os.environ.get('KILL_ALL_PROCESSES_TIMEOUT') else os.environ.get('KILL_ALL_PROCESSES_TIMEOUT')
 
 LOG_LEVEL_ERROR = 1
 LOG_LEVEL_WARN  = 1


### PR DESCRIPTION
Some of our processes we run in containers take far longer time to gracefully come down than 5 seconds. It would be nice to be able to configure the timeout through environment, so this patch should do so, falling back to 5 seconds as before.
