### PR TITLE
TERM should be something better than 'dumb' when running `docker exec -it ...`

### DIFF
--- a/image/prepare.sh
+++ b/image/prepare.sh
@@ -47,3 +47,6 @@ locale-gen en_US
 update-locale LANG=en_US.UTF-8 LC_CTYPE=en_US.UTF-8
 echo -n en_US.UTF-8 > /etc/container_environment/LANG
 echo -n en_US.UTF-8 > /etc/container_environment/LC_CTYPE
+
+## Set TERM to something better than 'dumb' when running `docker exec -it ...`
+echo -e "\nexport TERM=xterm\n" >> ~/.bashrc


### PR DESCRIPTION
See #282 