### PR TITLE
Fix Python executable not found

### DIFF
--- a/image/utilities.sh
+++ b/image/utilities.sh
@@ -9,3 +9,6 @@ ln -s /usr/bin/vim.tiny /usr/bin/vim
 
 ## This tool runs a command as another user and sets $HOME.
 cp /bd_build/bin/setuser /sbin/setuser
+
+## Set python executable
+ln -s /usr/bin/python3 /usr/bin/python


### PR DESCRIPTION
Some programs have "#!/usr/bin/env python" which is not found, this commit should fix this.