### PR TITLE
Have syslog forward to docker by itself

### DIFF
--- a/image/services/syslog-ng/syslog-forwarder.runit
+++ b/image/services/syslog-ng/syslog-forwarder.runit
@@ -1,2 +1,0 @@
-#!/bin/sh
-exec tail -F -n 0 /var/log/syslog

--- a/image/services/syslog-ng/syslog-ng.conf
+++ b/image/services/syslog-ng/syslog-ng.conf
@@ -74,6 +74,10 @@ destination d_xconsole { pipe("/dev/xconsole"); };
 # Debian only
 destination d_ppp { file("/var/log/ppp.log"); };
 
+# For docker forwarding
+destination d_stdout { pipe("/dev/stdout"); };
+destination d_stderr { pipe("/dev/stderr"); };
+
 ########################
 # Filters
 ########################
@@ -119,7 +123,7 @@ log { source(s_src); filter(f_cron); destination(d_cron); };
 log { source(s_src); filter(f_daemon); destination(d_daemon); };
 log { source(s_src); filter(f_kern); destination(d_kern); };
 log { source(s_src); filter(f_lpr); destination(d_lpr); };
-log { source(s_src); filter(f_syslog3); destination(d_syslog); };
+log { source(s_src); filter(f_syslog3); destination(d_syslog); destination(d_stdout); };
 log { source(s_src); filter(f_user); destination(d_user); };
 log { source(s_src); filter(f_uucp); destination(d_uucp); };
 

--- a/image/services/syslog-ng/syslog-ng.sh
+++ b/image/services/syslog-ng/syslog-ng.sh
@@ -15,10 +15,6 @@ touch /var/log/syslog
 chmod u=rw,g=r,o= /var/log/syslog
 cp $SYSLOG_NG_BUILD_PATH/syslog-ng.conf /etc/syslog-ng/syslog-ng.conf
 
-## Install syslog to "docker logs" forwarder.
-mkdir /etc/service/syslog-forwarder
-cp $SYSLOG_NG_BUILD_PATH/syslog-forwarder.runit /etc/service/syslog-forwarder/run
-
 ## Install logrotate.
 $minimal_apt_get_install logrotate
 cp $SYSLOG_NG_BUILD_PATH/logrotate_syslogng /etc/logrotate.d/syslog-ng


### PR DESCRIPTION
Using tail for forwarding is problematic, as tail starts to panic
when logrotate rotates the logs out and all hell breaks loose.
In addition it's an unnecessary complication: syslog-ng is
perfectly capable of doing it on its own.

This patch implements just that, removing syslog-forwarder and
having the syslog daemon handle the forwarding.
