### PR TITLE
Fix incorrect runit service name for syslog tail

### DIFF
--- a/image/services/syslog-ng/logrotate_syslogng
+++ b/image/services/syslog-ng/logrotate_syslogng
@@ -33,6 +33,6 @@
 	sharedscripts
 	postrotate
 		sv reload syslog-ng > /dev/null
-		sv restart cron-log-forwarder > /dev/null
+		sv restart syslog-forwarder > /dev/null
 	endscript
 }


### PR DESCRIPTION
The service restarted should be `syslog-forwarder`, not `cron-log-forwarder`. This causes issues when you have cron hooked on a mail setup and since cron-log-forwarder does not exist, logrotate exits with non-zero status code.

cc @FooBarWidget could you take a look at this?