### PR TITLE
Changes to upgrade this to Ubuntu-16.04

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 NAME = phusion/baseimage
-VERSION = 0.9.18
+VERSION = 0.9.19
 
 .PHONY: all build test tag_latest release ssh
 

--- a/image/Dockerfile
+++ b/image/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:14.04
+FROM ubuntu:16.04
 MAINTAINER Phusion <info@phusion.nl>
 
 ADD . /bd_build


### PR DESCRIPTION
Just the two line change to get this to 16.04. The test passes, I just had to add *-o identitiesonly=yes* to the ssh command line because I have too many ssh keys.

```bash
make test
env NAME=phusion/baseimage VERSION=0.9.19 ./test/runner.sh
 --> Starting insecure container
 --> Obtaining IP
 --> Enabling SSH in the container
No SSH host key available. Generating one...
Creating SSH2 RSA key; this may take some time ...
2048 SHA256:XIC8P17JTqt/SbKwtTpQyiv2otaC78Q9HAvMb3A5ySE root@ccc7dbb7340b (RSA)
Creating SSH2 DSA key; this may take some time ...
1024 SHA256:89eB8aq4JXx8/OjeMIFofZnR0cBrh5G4Uy4KIHU4lTg root@ccc7dbb7340b (DSA)
Creating SSH2 ECDSA key; this may take some time ...
256 SHA256:OtN2n0u/hucAROZxWw9/9cG4Kd5jrBBj3tX5bW7AT2M root@ccc7dbb7340b (ECDSA)
Creating SSH2 ED25519 key; this may take some time ...
256 SHA256:6t7FbTQZejXPDMpqwo8/0DnatStzs4HgaeMvjemBoFY root@ccc7dbb7340b (ED25519)
invoke-rc.d: policy-rc.d denied execution of restart.
ok: run: /etc/service/sshd: (pid 151) 1s
 --> Logging into container and running tests
Warning: Permanently added '172.17.0.2' (ECDSA) to the list of known hosts.
Checking whether all services are running...
  OK
 --> Stopping container
```
