### PR TITLE
Added support for running the command as nobody.

### DIFF
--- a/image/bin/my_init
+++ b/image/bin/my_init
@@ -287,8 +287,12 @@ def main(args):
 					exit_status = os.WEXITSTATUS(exit_code)
 					info("Runit exited with status %d" % exit_status)
 		else:
-			info("Running %s..." % " ".join(args.main_command))
-			pid = os.spawnvp(os.P_NOWAIT, args.main_command[0], args.main_command)
+			if args.nobody:
+				info("Running as nobody: %s..." % " ".join(args.main_command))
+				pid = os.spawnvp(os.P_NOWAIT, '/sbin/setuser', ['/sbin/setuser', 'nobody'] + args.main_command)
+			else:
+				info("Running as root: %s..." % " ".join(args.main_command))
+				pid = os.spawnvp(os.P_NOWAIT, args.main_command[0], args.main_command)
 			try:
 				exit_code = waitpid_reap_other_children(pid)
 				if exit_code is None:
@@ -331,6 +335,9 @@ parser.add_argument('--no-kill-all-on-exit', dest = 'kill_all_on_exit',
 parser.add_argument('--quiet', dest = 'log_level',
 	action = 'store_const', const = LOG_LEVEL_WARN, default = LOG_LEVEL_INFO,
 	help = 'Only print warnings and errors')
+parser.add_argument('--run-as-nobody', dest = 'nobody',
+	action = 'store_const', const = True, default = False,
+	help = 'Use internal user nobody for running the command')
 args = parser.parse_args()
 log_level = args.log_level
 


### PR DESCRIPTION
Running the command as nobody makes the system more secure.
It also solve an issue when the running container is writing
files to a mounted directory.

The option --run-as-nobody was added to /sbin/my_init script.