### PR TITLE
Add additional cleanup steps to further reduce image size

### DIFF
--- a/image/cleanup.sh
+++ b/image/cleanup.sh
@@ -6,6 +6,8 @@ set -x
 apt-get clean
 rm -rf /bd_build
 rm -rf /tmp/* /var/tmp/*
+rm -f /var/cache/apt/archives/*.deb
+rm -f /var/cache/apt/*cache.bin
 rm -rf /var/lib/apt/lists/*
 rm -f /etc/dpkg/dpkg.cfg.d/02apt-speedup
 


### PR DESCRIPTION
Added a couple of additional `rm` commands in cleanup.sh to clean up apt cache. Should reduce image size by about 30MB; specifically:

```
rm -f /var/cache/apt/archives/*.deb
rm -f /var/cache/apt/*cache.bin
```