### PR TITLE
Fix race condition in my_init causing container never to exit

### DIFF
--- a/image/bin/my_init
+++ b/image/bin/my_init
@@ -255,6 +255,7 @@ def wait_for_runit_services():
 		done = os.system("/usr/bin/sv status /etc/service/* | grep -q '^run:'") != 0
 		if not done:
 			time.sleep(0.1)
+			shutdown_runit_services()
 
 def install_insecure_key():
 	info("Installing insecure SSH key for user root")


### PR DESCRIPTION
The following race condition existed, and happened to me in production:

root@182b305fa0d5:~# /sbin/my_init -- ls
*** Running /etc/my_init.d/00_environment.sh...
*** Running /etc/my_init.d/00_regen_ssh_host_keys.sh...
*** Running /etc/my_init.d/01_bootstrap_djbdns.sh...
*** Booting runit daemon...
*** Runit started as PID 26
*** Running ls...
*** ls exited with status 0.
warning: /etc/service/cron: unable to open supervise/ok: file does not exist
warning: /etc/service/dnscache: unable to open supervise/ok: file does not exist
warning: /etc/service/sshd: unable to open supervise/ok: file does not exist
warning: /etc/service/syslog-forwarder: unable to open supervise/ok: file does not exist
warning: /etc/service/syslog-ng: unable to open supervise/ok: file does not exist
*** Shutting down runit daemon (PID 26)...

At that point the process hangs forever, because I believe the following has happened:

my_init starts runit
main command exits
my_init tells runit to exit
my_init tells runit services to exit (nothing happens since they aren't running yet)
runit starts its services
runit exits
my_init checks to see if runit services are still running, and they are, so repeat forever

This patch solves this issue in my production environment.