### PR TITLE
Support for pre- and post-shutdown scripts

### DIFF
--- a/image/bin/my_init
+++ b/image/bin/my_init
@@ -230,6 +230,26 @@ def run_startup_files():
 		info("Running /etc/rc.local...")
 		run_command_killable_and_import_envvars("/etc/rc.local")
 
+def run_pre_shutdown_scripts():
+	debug("Running pre-shutdown scripts...")
+
+	# Run /etc/my_init.pre_shutdown.d/*
+	for name in listdir("/etc/my_init.pre_shutdown.d"):
+		filename = "/etc/my_init.pre_shutdown.d/" + name
+		if is_exe(filename):
+			info("Running %s..." % filename)
+			run_command_killable(filename)
+
+def run_post_shutdown_scripts():
+	debug("Running post-shutdown scripts...")
+
+	# Run /etc/my_init.post_shutdown.d/*
+	for name in listdir("/etc/my_init.post_shutdown.d"):
+		filename = "/etc/my_init.post_shutdown.d/" + name
+		if is_exe(filename):
+			info("Running %s..." % filename)
+			run_command_killable(filename)
+
 def start_runit():
 	info("Booting runit daemon...")
 	pid = os.spawnl(os.P_NOWAIT, "/usr/bin/runsvdir", "/usr/bin/runsvdir",
@@ -276,7 +296,7 @@ def main(args):
 
 	if not args.skip_startup_files:
 		run_startup_files()
-	
+
 	runit_exited = False
 	exit_code = None
 
@@ -314,10 +334,12 @@ def main(args):
 		sys.exit(exit_status)
 	finally:
 		if not args.skip_runit:
+			run_pre_shutdown_scripts()
 			shutdown_runit_services()
 			if not runit_exited:
 				stop_child_process("runit daemon", runit_pid)
 			wait_for_runit_services()
+			run_post_shutdown_scripts()
 
 # Parse options.
 parser = argparse.ArgumentParser(description = 'Initialize the system.')

--- a/image/system_services.sh
+++ b/image/system_services.sh
@@ -6,6 +6,8 @@ set -x
 ## Install init process.
 cp /bd_build/bin/my_init /sbin/
 mkdir -p /etc/my_init.d
+mkdir -p /etc/my_init.pre_shutdown.d
+mkdir -p /etc/my_init.post_shutdown.d
 mkdir -p /etc/container_environment
 touch /etc/container_environment.sh
 touch /etc/container_environment.json


### PR DESCRIPTION
This allows users to place files in `/etc/my_init.post_shutdown.d` and `/etc/my_init.pre_shutdown.d` folders.

This is needed to allow backing up services which require Linux filesystem features which are not available on Windows / OS X hosts.

Example PostgreSQL pre-shutdown script, using pg_dumpall:

```
#!/bin/sh
echo 'PostgreSQL dump started'
set -e

BACKUP_DIR=/shared/postgresql/backup/dump

# run
mkdir -p $BACKUP_DIR
chown -R postgres:postgres $BACKUP_DIR
su - postgres -c "pg_dumpall --clean --if-exists | gzip > \"$BACKUP_DIR/sqldump.sql.gz\""
echo 'PostgreSQL dump finished'
```

Example PostgreSQL pre-shutdown script, using pg_dump for a single database:

```
#!/bin/sh
set -e

echo 'PostgreSQL backup started'

BACKUP_DIR=/shared/postgresql/backup

# run
mkdir -p $BACKUP_DIR
chown -R postgres:postgres $BACKUP_DIR

su - postgres -c "pg_dump -d app --no-owner --no-privileges | sed '/^COMMENT ON EXTENSION plpgsql/d' | gzip > \"$BACKUP_DIR/sqldump.sql.gz\""
echo 'PostgreSQL dump finished'
```

Example PostgreSQL post-shutdown script, using rsync:

```
#!/bin/sh
echo 'PostgreSQL rsync started'
set -e

BACKUP_DIR=/shared/postgresql/backup/data

# run
mkdir -p $BACKUP_DIR
chown -R postgres:postgres $BACKUP_DIR
rsync -a --delete --checksum /data/pgsql/ $BACKUP_DIR/
echo 'PostgreSQL rsync finished'
```
