### PR TITLE
Removing -f option of `docker tag`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ test:
 	env NAME=$(NAME) VERSION=$(VERSION) ./test/runner.sh
 
 tag_latest:
-	docker tag -f $(NAME):$(VERSION) $(NAME):latest
+	docker tag $(NAME):$(VERSION) $(NAME):latest
 
 release: test tag_latest
 	@if ! docker images $(NAME) | awk '{ print $$2 }' | grep -q -F $(VERSION); then echo "$(NAME) version $(VERSION) is not yet built. Please run 'make build'"; false; fi


### PR DESCRIPTION
Removing -f option of `docker tag` since this option is gone in docker 1.12.0.
