### PR TITLE
Reconfigure locales and expose them in Dockerfile

### DIFF
--- a/image/Dockerfile
+++ b/image/Dockerfile
@@ -9,4 +9,8 @@ RUN /bd_build/prepare.sh && \
 	/bd_build/fix_pam_bug.sh && \
 	/bd_build/cleanup.sh
 
+ENV LANG en_US.UTF-8
+ENV LANGUAGE en_US:en
+ENV LC_ALL en_US.UTF-8
+
 CMD ["/sbin/my_init"]


### PR DESCRIPTION
While the locales are generated with locale-gen, this does not enforce
the en_US.UTF-8 locale inside the container. The locales package needs
to dpkg-reconfigure'd after the locales creation. They also need to get
exposed in Dockerfile.

See the following links for more information:
- https://github.com/docker/docker/issues/2424
- http://jaredmarkell.com/docker-and-locales/
