### PR TITLE
override the logrotate.conf without `su root syslog`

### DIFF
--- a/image/services/syslog-ng/logrotate.conf
+++ b/image/services/syslog-ng/logrotate.conf
@@ -1,0 +1,36 @@
+# see "man logrotate" for details
+# rotate log files weekly
+weekly
+
+# use the syslog group by default, since this is the owning group
+# of /var/log/syslog.
+# su root syslog
+
+# keep 4 weeks worth of backlogs
+rotate 4
+
+# create new (empty) log files after rotating old ones
+create
+
+# uncomment this if you want your log files compressed
+#compress
+
+# packages drop log rotation information into this directory
+include /etc/logrotate.d
+
+# no packages own wtmp, or btmp -- we'll rotate them here
+/var/log/wtmp {
+    missingok
+    monthly
+    create 0664 root utmp
+    rotate 1
+}
+
+/var/log/btmp {
+    missingok
+    monthly
+    create 0660 root utmp
+    rotate 1
+}
+
+# system-specific logs may be configured here

--- a/image/services/syslog-ng/syslog-ng.sh
+++ b/image/services/syslog-ng/syslog-ng.sh
@@ -21,4 +21,5 @@ cp $SYSLOG_NG_BUILD_PATH/syslog-forwarder.runit /etc/service/syslog-forwarder/ru
 
 ## Install logrotate.
 $minimal_apt_get_install logrotate
+cp $SYSLOG_NG_BUILD_PATH/logrotate.conf /etc/logrotate.conf
 cp $SYSLOG_NG_BUILD_PATH/logrotate_syslogng /etc/logrotate.d/syslog-ng


### PR DESCRIPTION
Fixes https://github.com/phusion/baseimage-docker/issues/338

Briefly, the syslog user does not exist any more in ubuntu:16.04, the default configuration of logrotate still uses syslog as the group, we need to override the default behavior.
