### PR TITLE
Match logrotate and syslog configuration

### DIFF
--- a/image/Dockerfile
+++ b/image/Dockerfile
@@ -7,6 +7,7 @@ RUN /bd_build/prepare.sh && \
 	/bd_build/system_services.sh && \
 	/bd_build/utilities.sh && \
 	/bd_build/fix_pam_bug.sh && \
+	/bd_build/fix_logrotate.sh && \
 	/bd_build/cleanup.sh
 
 CMD ["/sbin/my_init"]

--- a/image/fix_logrotate.sh
+++ b/image/fix_logrotate.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+sed -i 's/syslog/adm/g' /etc/logrotate.conf


### PR DESCRIPTION
On a vanilla baseimage daily logrotate is failing:

``` sh
root@84c9d1b59665:/# /etc/cron.daily/logrotate 
error: /etc/logrotate.conf:7 unknown group 'syslog'
root@84c9d1b59665:/# 
```

I've attached a fix.
