### PR TITLE
Fix logrotate default group

### DIFF
--- a/image/services/syslog-ng/syslog-ng.sh
+++ b/image/services/syslog-ng/syslog-ng.sh
@@ -22,3 +22,6 @@ cp $SYSLOG_NG_BUILD_PATH/syslog-forwarder.runit /etc/service/syslog-forwarder/ru
 ## Install logrotate.
 $minimal_apt_get_install logrotate
 cp $SYSLOG_NG_BUILD_PATH/logrotate_syslogng /etc/logrotate.d/syslog-ng
+
+## Change logrotate default group
+sed -i 's/su root syslog/su root adm/' /etc/logrotate.conf


### PR DESCRIPTION
Use 'adm' group instead of 'syslog' group.

There is no 'syslog' group on the image and 'syslog-ng' package does not create it.
Logrotate's config file suggests that its user must have owning group of /var/log/syslog.
Hence the use of 'adm' group fixes the problem.

Signed-off-by: Vinicius Tinti viniciustinti@gmail.com
