### PR TITLE
WIP: fix libgc bug for i386 baseimage-docker

### DIFF
--- a/image/Dockerfile
+++ b/image/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:16.04
+FROM i386/ubuntu:16.04
 MAINTAINER Phusion <info@phusion.nl>
 
 COPY . /bd_build
@@ -6,6 +6,7 @@ COPY . /bd_build
 RUN /bd_build/prepare.sh && \
 	/bd_build/system_services.sh && \
 	/bd_build/utilities.sh && \
+	/bd_build/fix_libgc_bug.sh && \
 	/bd_build/fix_pam_bug.sh && \
 	/bd_build/cleanup.sh
 

--- a/image/cleanup.sh
+++ b/image/cleanup.sh
@@ -4,7 +4,7 @@ source /bd_build/buildconfig
 set -x
 
 apt-get clean
-ls -d -1 /bd_build/**/* | grep -v "cleanup.sh" | grep -v "buildconfig" | xargs rm -f
+ls -d -1 /bd_build/**/* | grep -v "cleanup.sh" | grep -v "buildconfig" | grep -v "services/" | xargs rm -f
 rm -rf /tmp/* /var/tmp/*
 rm -rf /var/lib/apt/lists/*
 

--- a/image/fix_libgc_bug.sh
+++ b/image/fix_libgc_bug.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+set -e
+source /bd_build/buildconfig
+set -x
+
+# Fixes https://github.com/docker/docker/issues/6345
+# The Github is closed, but some apps such as pbuilder still triggers it.
+
+export CONFIGURE_OPTS=--disable-audit
+cd /tmp
+
+$minimal_apt_get_install gdebi-core
+apt-get build-dep -y --no-install-recommends libgc
+apt-get source -y libgc
+echo "#define NO_GETCONTEXT" >> libgc-7.4.2/include/private/gcconfig.h
+pushd libgc-7.4.2
+dpkg-buildpackage -b
+popd
+gdebi -n libgc1c2_7.4.2-7.3ubuntu0.1_i386.deb
+rm -rf *.deb *.gz *.dsc *.changes libgc-*
+
+# Unfortunately there is no way to automatically remove build deps, so we do this manually.
+apt-get remove -y gdebi-core autoconf automake autopoint autotools-dev binutils bsdmainutils \
+	build-essential bzip2 cpp cpp-5 debhelper dh-autoreconf dh-strip-nondeterminism \
+	diffstat dpkg-dev g++ g++-5 gcc gcc-5 gettext gettext-base groff-base hardening-includes \
+	intltool-debian libapt-pkg-perl libarchive-zip-perl libasan2 libasprintf0v5 libatomic-ops-dev \
+	libatomic1 libc-dev-bin libc6-dev libcc1-0 libcgi-pm-perl libcilkrts5 libclass-accessor-perl \
+	libclone-perl libcroco3 libdata-alias-perl libdigest-hmac-perl libdpkg-perl libemail-valid-perl \
+	libexporter-tiny-perl libfile-basedir-perl libfile-stripnondeterminism-perl libgcc-5-dev libgdbm3 \
+	libgomp1 libhtml-parser-perl libhtml-tagset-perl libicu55 libio-pty-perl libio-socket-inet6-perl \
+	libio-socket-ssl-perl libio-string-perl libipc-run-perl libipc-system-simple-perl libisl15 \
+	libitm1 liblist-moreutils-perl liblocale-gettext-perl libmailtools-perl libmpc3 libmpfr4 libmpx0 \
+	libnet-dns-perl libnet-domain-tld-perl libnet-ip-perl libnet-smtp-ssl-perl libnet-ssleay-perl \
+	libparse-debianchangelog-perl libperl5.22 libpipeline1 libquadmath0 libsigsegv2 libsocket6-perl \
+	libstdc++-5-dev libsub-name-perl libtext-levenshtein-perl libtimedate-perl libtool libubsan0 \
+	libunistring0 liburi-perl libxml2 libyaml-libyaml-perl lintian linux-libc-dev m4 make man-db \
+	netbase patch patchutils perl perl-modules-5.22 pkg-config pkg-kde-tools po-debconf t1utils \
+	xz-utils
+
+apt-get remove -y gdebi-core
+apt-get autoremove -y

--- a/image/fix_pam_bug.sh
+++ b/image/fix_pam_bug.sh
@@ -22,10 +22,10 @@ apt-get remove -y gdebi-core autoconf automake autopoint autotools-dev binutils 
 	groff-base intltool-debian libarchive-zip-perl libasan2 libasprintf0v5 libatomic1 \
 	libaudit-dev libc-dev-bin libc6-dev libcc1-0 libcilkrts5 libcrack2 libcrack2-dev libcroco3 \
 	libdb-dev libdb5.3-dev libdpkg-perl libfile-stripnondeterminism-perl libfl-dev libgc1c2 \
-	libgcc-5-dev libgdbm3 libgomp1 libgpm2 libicu55 libisl15 libitm1 liblsan0 libmpc3 \
+	libgcc-5-dev libgdbm3 libgomp1 libgpm2 libicu55 libisl15 libitm1 libmpc3 \
 	libmpfr4 libmpx0 libpcre16-3 libpcre3-dev libpcre32-3 libpcrecpp0v5 libperl5.22 \
 	libpipeline1 libquadmath0 libselinux1-dev libsepol1-dev libsigsegv2 libstdc++-5-dev \
-	libtimedate-perl libtool libtsan0 libubsan0 libunistring0 libxml2 libxml2-utils \
+	libtimedate-perl libtool libubsan0 libunistring0 libxml2 libxml2-utils \
 	libxslt1.1 linux-libc-dev m4 make man-db patch perl perl-modules-5.22 pkg-config \
 	po-debconf quilt sgml-base sgml-data w3m xml-core xsltproc xz-utils
 


### PR DESCRIPTION
Still fails at attempting to uninstall

```
E: Unable to locate package liblsan0
E: Unable to locate package libtsan0
```

package we evidently didn't need...