### PR TITLE
Revert "Preserve /build/{cleanup.sh,buildconfig} files."

### DIFF
--- a/image/cleanup.sh
+++ b/image/cleanup.sh
@@ -4,7 +4,7 @@ source /bd_build/buildconfig
 set -x
 
 apt-get clean
-ls -d -1 /bd_build/**/* | grep -v "cleanup.sh" | grep -v "buildconfig" | xargs rm -f
+rm -rf /bd_build
 rm -rf /tmp/* /var/tmp/*
 rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
Reverts phusion/baseimage-docker#188

This is breaking the build.