### PR TITLE
Correct translation of syslog-ng driver `system()` on Docker

### DIFF
--- a/image/services/syslog-ng/syslog-ng.conf
+++ b/image/services/syslog-ng/syslog-ng.conf
@@ -18,7 +18,7 @@ options { chain_hostnames(off); flush_lines(0); use_dns(no); use_fqdn(no);
 # Logs may come from unix stream, but not from another machine.
 #
 source s_src {
-       unix-stream("/dev/log");
+       unix-dgram("/dev/log");
        internal();
 };
 


### PR DESCRIPTION
Please refer to commit message for details.

Closes #277 (already closed BTW).