### PR TITLE
Suppress the status reports from "sv -w"

### DIFF
--- a/image/bin/my_init
+++ b/image/bin/my_init
@@ -247,7 +247,7 @@ def wait_for_runit_or_interrupt(pid):
 def shutdown_runit_services(quiet = False):
 	if not quiet:
 		debug("Begin shutting down runit services...")
-	os.system("/usr/bin/sv -w %d down /etc/service/*" % KILL_PROCESS_TIMEOUT)
+	os.system("/usr/bin/sv -w %d down /etc/service/* > /dev/null" % KILL_PROCESS_TIMEOUT)
 
 def wait_for_runit_services():
 	debug("Waiting for runit services to exit...")


### PR DESCRIPTION
The status info printed out with the new "-w" option of sv not only is annoying but also can potentially break the logic of Docker images derived from this image, which may assume empty screen output by default. The easy fix is to redirect the screen output to /dev/null.