### PR TITLE
feat: allow users to specify an alternative init directory

### DIFF
--- a/image/bin/my_init
+++ b/image/bin/my_init
@@ -251,7 +251,7 @@ def kill_all_processes(time_limit):
 
 
 def run_startup_files():
-    # Run ENV_INIT_DIRECTORY*
+    # Run ENV_INIT_DIRECTORY/*
     for name in listdir(ENV_INIT_DIRECTORY):
         filename = os.path.join(ENV_INIT_DIRECTORY, name)
         if is_exe(filename):

--- a/image/bin/my_init
+++ b/image/bin/my_init
@@ -12,6 +12,8 @@ import stat
 import sys
 import time
 
+ENV_INIT_DIRECTORY = os.environ.get('ENV_INIT_DIRECTORY', '/etc/my_init.d')
+
 KILL_PROCESS_TIMEOUT = int(os.environ.get('KILL_PROCESS_TIMEOUT', 5))
 KILL_ALL_PROCESSES_TIMEOUT = int(os.environ.get('KILL_ALL_PROCESSES_TIMEOUT', 5))
 
@@ -249,9 +251,9 @@ def kill_all_processes(time_limit):
 
 
 def run_startup_files():
-    # Run /etc/my_init.d/*
-    for name in listdir("/etc/my_init.d"):
-        filename = "/etc/my_init.d/" + name
+    # Run ENV_INIT_DIRECTORY*
+    for name in listdir(ENV_INIT_DIRECTORY):
+        filename = os.path.join(ENV_INIT_DIRECTORY, name)
         if is_exe(filename):
             info("Running %s..." % filename)
             run_command_killable_and_import_envvars(filename)


### PR DESCRIPTION
In some existing environments, packages might already use another environment for the purpose this `/etc/my_init.d` directory serves.