### PR TITLE
sanitize_shenvname returns string with [0-9a-zA-Z_] characters

### DIFF
--- a/image/bin/my_init
+++ b/image/bin/my_init
@@ -20,8 +20,6 @@ LOG_LEVEL_WARN = 1
 LOG_LEVEL_INFO = 2
 LOG_LEVEL_DEBUG = 3
 
-SHENV_NAME_WHITELIST_REGEX = re.compile('[^\w\-_\.]')
-
 log_level = None
 
 terminated_child_processes = {}
@@ -130,7 +128,8 @@ def shquote(s):
 
 
 def sanitize_shenvname(s):
-    return re.sub(SHENV_NAME_WHITELIST_REGEX, "_", s)
+    """Return string with [0-9a-zA-Z_] characters"""
+    return re.sub(re.compile("\W"), "_", s)
 
 
 # Waits for the child process with the given PID, while at the same time

--- a/image/bin/my_init
+++ b/image/bin/my_init
@@ -20,6 +20,8 @@ LOG_LEVEL_WARN = 1
 LOG_LEVEL_INFO = 2
 LOG_LEVEL_DEBUG = 3
 
+SHENV_NAME_WHITELIST_REGEX = re.compile('\W')
+
 log_level = None
 
 terminated_child_processes = {}
@@ -129,7 +131,7 @@ def shquote(s):
 
 def sanitize_shenvname(s):
     """Return string with [0-9a-zA-Z_] characters"""
-    return re.sub(re.compile("\W"), "_", s)
+    return re.sub(SHENV_NAME_WHITELIST_REGEX, "_", s)
 
 
 # Waits for the child process with the given PID, while at the same time


### PR DESCRIPTION
In docker logs for my application I'm getting a lot of noise like this:

```
/etc/profile.d/container_environment.sh: line 10: export: `LIVE.APPLICATION.DEV_PORT_22_TCP_PROTO=tcp': not a valid identifier
/etc/profile.d/container_environment.sh: line 14: export: `LIVE.APPLICATION.DEV_PORT_443_TCP_ADDR=172.17.0.10': not a valid identifier
/etc/profile.d/container_environment.sh: line 24: export: `LIVE.UXPIN.DEV_ENV_MODE=compose': not a valid identifier
```
because it's auto-generated from `docker-compose.yml` configuration

```
app:
    links:
        - balancer:live.application.dev
```

What do you think about restricting characters in env variable name only to the following set `[0-9a-zA-Z_]`  ?