### PR TITLE
configured syslog-ng to log to stdout directly instead of using tail

### DIFF
--- a/image/services/syslog-ng/logrotate_syslogng
+++ b/image/services/syslog-ng/logrotate_syslogng
@@ -8,7 +8,6 @@
 	compress
 	postrotate
 		sv reload syslog-ng > /dev/null
-		sv restart syslog-forwarder > /dev/null
 	endscript
 }
 
@@ -34,6 +33,5 @@
 	sharedscripts
 	postrotate
 		sv reload syslog-ng > /dev/null
-		sv restart syslog-forwarder > /dev/null
 	endscript
 }

--- a/image/services/syslog-ng/syslog-forwarder.runit
+++ b/image/services/syslog-ng/syslog-forwarder.runit
@@ -1,2 +1,0 @@
-#!/bin/sh
-exec tail -F -n 0 /var/log/syslog

--- a/image/services/syslog-ng/syslog-ng.conf
+++ b/image/services/syslog-ng/syslog-ng.conf
@@ -74,6 +74,9 @@ destination d_xconsole { pipe("/dev/xconsole"); };
 # Debian only
 destination d_ppp { file("/var/log/ppp.log"); };
 
+# stdout for docker
+destination d_stdout { pipe("/dev/stdout"); };
+
 ########################
 # Filters
 ########################
@@ -119,7 +122,7 @@ log { source(s_src); filter(f_cron); destination(d_cron); };
 log { source(s_src); filter(f_daemon); destination(d_daemon); };
 log { source(s_src); filter(f_kern); destination(d_kern); };
 log { source(s_src); filter(f_lpr); destination(d_lpr); };
-log { source(s_src); filter(f_syslog3); destination(d_syslog); };
+log { source(s_src); filter(f_syslog3); destination(d_syslog); destination(d_stdout); };
 log { source(s_src); filter(f_user); destination(d_user); };
 log { source(s_src); filter(f_uucp); destination(d_uucp); };
 

--- a/image/services/syslog-ng/syslog-ng.sh
+++ b/image/services/syslog-ng/syslog-ng.sh
@@ -15,10 +15,6 @@ touch /var/log/syslog
 chmod u=rw,g=r,o= /var/log/syslog
 cp $SYSLOG_NG_BUILD_PATH/syslog-ng.conf /etc/syslog-ng/syslog-ng.conf
 
-## Install syslog to "docker logs" forwarder.
-mkdir /etc/service/syslog-forwarder
-cp $SYSLOG_NG_BUILD_PATH/syslog-forwarder.runit /etc/service/syslog-forwarder/run
-
 ## Install logrotate.
 $minimal_apt_get_install logrotate
 cp $SYSLOG_NG_BUILD_PATH/logrotate.conf /etc/logrotate.conf


### PR DESCRIPTION
in reponse to: #437 Syslog messages are not forwarded
- changed syslog-ng config to log to stdout
- maintain log files inside container
- removed syslog-forwarder (setup, service, logrotate restart) 