### PR TITLE
Gracefully handle syslog-ng shutdown

### DIFF
--- a/image/services/syslog-ng/syslog-ng.shutdown
+++ b/image/services/syslog-ng/syslog-ng.shutdown
@@ -20,5 +20,8 @@ syslogng_wait() {
     return $RET
 }
 
-kill $(cat "$PIDFILE")
+if [ -f "$PIDFILE" ]; then
+    kill $(cat "$PIDFILE")
+fi
+
 syslogng_wait 0 $?


### PR DESCRIPTION
This fixes a minor issue with the shutdown process of `syslog-ng` introduced with PR #425.

The problem is that under some conditions, when you kill the container, `syslog-ng` gets the kill command from the init process before the shutdown sequence, and the `syslog-ng.shutdown` script tries to `cat` syslog-ng's PID file, but it's already gone.

I can reliably reproduce this issue by running the container interactively, then pressing `CTRL-C`, but I suspect it happens also in the wild when docker/docker-compose sends the kill command to the PID 0 init system.

Here's the current effect (note that the image is the current `master` branch with no modifications):
`$ docker run -ti --rm kamermans/phusion-baseimage:0.9.23-rc2`
```
*** Running /etc/my_init.d/00_regen_ssh_host_keys.sh...
*** Running /etc/my_init.d/10_syslog-ng.init...
Nov  1 21:10:04 e0756e33d57f syslog-ng[11]: syslog-ng starting up; version='3.5.6'
Nov  1 21:10:04 e0756e33d57f syslog-ng[11]: WARNING: you are using the pipe driver, underlying file is not a FIFO, it should be used by file(); filename='/dev/stdout'
Nov  1 21:10:05 e0756e33d57f syslog-ng[11]: EOF on control channel, closing connection;
*** Running /etc/rc.local...
*** Booting runit daemon...
*** Runit started as PID 17
Nov  1 21:10:05 e0756e33d57f cron[20]: (CRON) INFO (pidfile fd = 3)
Nov  1 21:10:05 e0756e33d57f cron[20]: (CRON) INFO (Running @reboot jobs)
^C
Nov  1 21:10:11 e0756e33d57f syslog-ng[11]: syslog-ng shutting down; version='3.5.6'
*** Shutting down runit daemon (PID 17)...
*** Running /etc/my_init.post_shutdown.d/10_syslog-ng.shutdown...
cat: /var/run/syslog-ng.pid: No such file or directory
kill: usage: kill [-s sigspec | -n signum | -sigspec] pid | jobspec ... or kill -l [sigspec]
*** /etc/my_init.post_shutdown.d/10_syslog-ng.shutdown failed with status 1

*** Killing all processes...
```

This is the part that I am talking about:
```
*** Running /etc/my_init.post_shutdown.d/10_syslog-ng.shutdown...
cat: /var/run/syslog-ng.pid: No such file or directory
kill: usage: kill [-s sigspec | -n signum | -sigspec] pid | jobspec ... or kill -l [sigspec]
*** /etc/my_init.post_shutdown.d/10_syslog-ng.shutdown failed with status 1
```

This PR simply checks if the PID file is there before attempting to `cat` it.  Note that there is still technically some chance that the PID file disappears between the `-f` and the `cat`, but it would likely be so rare that it's not worth coding around.