### PR TITLE
Fork syslog-ng into a new process group via bash monitor mode

### DIFF
--- a/image/services/syslog-ng/syslog-ng.init
+++ b/image/services/syslog-ng/syslog-ng.init
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -e
+set -em
 
 # If /dev/log is either a named pipe or it was placed there accidentally,
 # e.g. because of the issue documented at https://github.com/phusion/baseimage-docker/pull/25,


### PR DESCRIPTION
This prevents SIGINT from a user interrupt from prematurely quitting syslog-ng.
Re: Issue https://github.com/phusion/baseimage-docker/issues/450 and PR https://github.com/phusion/baseimage-docker/pull/447

From the bash manual:

```text
-m      Monitor mode.  Job control is enabled.  This option is on by default for interactive shells on systems that support it (see JOB CONTROL above).  Back-
                      ground processes run in a separate process group and a line containing their exit status is printed upon their completion.
```

When an interactive docker tty receives SIGINT, it forwards the signal to all processes in the tty's process group (https://www.cs.ucsb.edu/~almeroth/classes/W99.276/assignment1/signals.html). By forking syslog-ng into it's own process group with bash monitor mode, this prevents the SIGINT sent to the tty from being sent to syslog-ng, and the normal shutdown procedure is then able to shutdown syslog-ng at the appropriate point in the sequence.