### PR TITLE
fixed syslog warning when using --tty as described in #468

### DIFF
--- a/image/services/syslog-ng/syslog-ng.conf
+++ b/image/services/syslog-ng/syslog-ng.conf
@@ -75,7 +75,7 @@ destination d_xconsole { pipe("/dev/xconsole"); };
 destination d_ppp { file("/var/log/ppp.log"); };
 
 # stdout for docker
-destination d_stdout { pipe("/dev/stdout"); };
+destination d_stdout { ##SYSLOG_OUTPUT_MODE_DEV_STDOUT##("/dev/stdout"); };
 
 ########################
 # Filters

--- a/image/services/syslog-ng/syslog-ng.init
+++ b/image/services/syslog-ng/syslog-ng.init
@@ -7,6 +7,13 @@ set -em
 if [ ! -S /dev/log ]; then rm -f /dev/log; fi
 if [ ! -S /var/lib/syslog-ng/syslog-ng.ctl ]; then rm -f /var/lib/syslog-ng/syslog-ng.ctl; fi
 
+# determine output mode on /dev/stdout because of the issue documented at https://github.com/phusion/baseimage-docker/issues/468
+if [ -p /dev/stdout ]; then
+  sed -i 's/##SYSLOG_OUTPUT_MODE_DEV_STDOUT##/pipe/' /etc/syslog-ng/syslog-ng.conf
+else
+  sed -i 's/##SYSLOG_OUTPUT_MODE_DEV_STDOUT##/file/' /etc/syslog-ng/syslog-ng.conf
+fi
+
 PIDFILE="/var/run/syslog-ng.pid"
 SYSLOGNG_OPTS=""
 


### PR DESCRIPTION
As described in #468 syslog-ng issues a warning when using a pipe driver on a file or the other way around. This fixes that by selecting the correct IO mode at container runtime.