### PR TITLE
Allow 'make test' to work on macOS by publishing the SSH port

### DIFF
--- a/test/runner.sh
+++ b/test/runner.sh
@@ -17,13 +17,13 @@ function cleanup()
 PWD=`pwd`
 
 echo " --> Starting insecure container"
-ID=`docker run -d -v $PWD/test:/test $NAME:$VERSION /sbin/my_init --enable-insecure-key`
+ID=`docker run -d -p 22 -v $PWD/test:/test $NAME:$VERSION /sbin/my_init --enable-insecure-key`
 sleep 1
 
-echo " --> Obtaining IP"
-IP=`docker inspect -f "{{ .NetworkSettings.IPAddress }}" "$ID"`
-if [[ "$IP" = "" ]]; then
-	abort "Unable to obtain container IP"
+echo " --> Obtaining SSH port number"
+SSHPORT=`docker inspect --format='{{(index (index .NetworkSettings.Ports "22/tcp") 0).HostPort}}' "$ID"`
+if [[ "$SSHPORT" = "" ]]; then
+	abort "Unable to obtain container SSH port number"
 fi
 
 trap cleanup EXIT
@@ -38,5 +38,5 @@ echo " --> Logging into container and running tests"
 cp image/services/sshd/keys/insecure_key /tmp/insecure_key
 chmod 600 /tmp/insecure_key
 sleep 1 # Give container some more time to start up.
-ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -i /tmp/insecure_key root@$IP \
+ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -i /tmp/insecure_key -p $SSHPORT root@127.0.0.1 \
 	/bin/bash /test/test.sh


### PR DESCRIPTION
Allow 'make test' to work on macOS by publishing the SSH port and using that during tests, as the IP address cannot be directly reached on macOS docker.

As far as I can tell, these changes should not affect building on Linux.