### PR TITLE
changing the base to Ubuntu 18.04 LTS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
-NAME = hurr1k4ne/baseimage
-VERSION = 0.11.0
+NAME = phusion/baseimage
+VERSION = 0.10.1
 
 .PHONY: all build test tag_latest release ssh
 

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
-NAME = phusion/baseimage
-VERSION = 0.10.1
+NAME = hurr1k4ne/baseimage
+VERSION = 0.11.0
 
 .PHONY: all build test tag_latest release ssh
 

--- a/image/Dockerfile
+++ b/image/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:16.04
+FROM ubuntu:18.04
 MAINTAINER Phusion <info@phusion.nl>
 
 COPY . /bd_build

--- a/image/Dockerfile
+++ b/image/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04
+FROM ubuntu:16.04
 MAINTAINER Phusion <info@phusion.nl>
 
 COPY . /bd_build


### PR DESCRIPTION
i started changing the ubuntu release to 18.04 LTS because i needed more actual libraries.

It seemed to work quite well.
I tested to build different container beforehand based on debian:stretch and ubuntu:xenial.
worked like a charm