### PR TITLE
use `sv force-stop` instead of `sv down` to stop services

### DIFF
--- a/image/bin/my_init
+++ b/image/bin/my_init
@@ -303,7 +303,7 @@ def wait_for_runit_or_interrupt(pid):
 def shutdown_runit_services(quiet=False):
     if not quiet:
         debug("Begin shutting down runit services...")
-    os.system("/usr/bin/sv -w %d down /etc/service/* > /dev/null" % KILL_PROCESS_TIMEOUT)
+    os.system("/usr/bin/sv -w %d force-stop /etc/service/* > /dev/null" % KILL_PROCESS_TIMEOUT)
 
 
 def wait_for_runit_services():


### PR DESCRIPTION
Use `sv force-stop` so that a SIGTERM is escalated to SIGKILL after the specified number of seconds.

fixes #506 