### PR TITLE
Delete double args

### DIFF
--- a/image/bin/my_init
+++ b/image/bin/my_init
@@ -289,7 +289,7 @@ def run_post_shutdown_scripts():
 
 def start_runit():
     info("Booting runit daemon...")
-    pid = os.spawnl(os.P_NOWAIT, "/usr/bin/runsvdir", "/usr/bin/runsvdir",
+    pid = os.spawnl(os.P_NOWAIT, "/usr/bin/runsvdir",
                     "-P", "/etc/service")
     info("Runit started as PID %d" % pid)
     return pid


### PR DESCRIPTION
I found duplicate arguments in the command. 
It does not look like they need it here, thanks.