### PR TITLE
Fixed wrong line breaks in syslog-ng's logrotate config

### DIFF
--- a/image/services/syslog-ng/logrotate_syslogng
+++ b/image/services/syslog-ng/logrotate_syslogng
@@ -1,5 +1,4 @@
-/var/log/syslog
-{
+/var/log/syslog {
 	rotate 7
 	daily
 	missingok
@@ -24,8 +23,7 @@
 /var/log/lpr.log
 /var/log/cron.log
 /var/log/debug
-/var/log/messages
-{
+/var/log/messages {
 	rotate 4
 	weekly
 	missingok


### PR DESCRIPTION
The line breaks in syslog-ng's logrotate config cause the following error and this is the fix.

> /etc/cron.daily/logrotate:
error: error running non-shared postrotate script for /var/log/syslog of '/var/log/syslog
'
run-parts: /etc/cron.daily/logrotate exited with return code 1

