### PR TITLE
Remove python bytecode

### DIFF
--- a/image/cleanup.sh
+++ b/image/cleanup.sh
@@ -8,4 +8,8 @@ find /bd_build/ -not \( -name 'bd_build' -or -name 'buildconfig' -or -name 'clea
 rm -rf /tmp/* /var/tmp/*
 rm -rf /var/lib/apt/lists/*
 
+# clean up python bytecode
+find / -name *.pyc -delete
+find / -name *__pycache__* -delete
+
 rm -f /etc/ssh/ssh_host_*


### PR DESCRIPTION
The image contains python bytecode files (`*.pyc`). Removing them will reduce the size of the image by ~10MB. Removing them will not have any real impact as they will be recreated on first run. More info on `*.pyc` files [here](http://effbot.org/pyfaq/how-do-i-create-a-pyc-file.htm)

You can check the size of the existing *.pyc files using:

``` bash
find / -name *.pyc -exec du -ch {} + | tail -n1
```

The pull request just adds two lines that remove the relevant files and the directories that contain them 