### PR TITLE
Fix .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
-sudo: required
+os: linux
+
+dist: bionic
 
 language: c
 
@@ -25,8 +27,6 @@ env:
     - PLATFORM=amd64 QEMU_ARCH=amd64   TAG_ARCH=amd64
     - PLATFORM=arm64 QEMU_ARCH=aarch64 TAG_ARCH=arm64
     - PLATFORM=arm   QEMU_ARCH=arm     TAG_ARCH=arm
-
-stage: Compile
 
 before_script:
   - echo '{"experimental":true}' | sudo tee /etc/docker/daemon.json


### PR DESCRIPTION
- `sudo` key is deprecated and has no more effect
- `os` is forced to `linux` in case the default ever changes
- `dist` is set to `bionic` (the default is `xenial`).
  - At the time of writing building would fail if it this would be changed to `focal`. In the future this will probably work but this should not be changed in this PR
  - Setting this to `bionic` (or leaving it at `xenial`) does not change the ubuntu version of the image itself. This only affects the building process.
- `stage` is not available in the root of the file