### PR TITLE
Add instructions to install "vagrant-disksize" plug-in

### DIFF
--- a/README.md
+++ b/README.md
@@ -585,6 +585,12 @@ Clone this repository:
 
 Start a virtual machine with Docker in it. You can use the Vagrantfile that we've already provided.
 
+First, install `vagrant-disksize` plug-in:
+
+    vagrant plugin install vagrant-disksize:
+
+Then, start the virtual machine
+
     vagrant up
     vagrant ssh
     cd /vagrant


### PR DESCRIPTION
Add instructions to install "vagrant-disksize" plug-in in order to avoid "Unknown configuration section 'disksize'." error in Vagrantfile.