### PR TITLE
Update syslog-ng.conf from Ubuntu 20.04

### DIFF
--- a/image/services/syslog-ng/syslog-ng.conf
+++ b/image/services/syslog-ng/syslog-ng.conf
@@ -1,4 +1,4 @@
-@version: 3.13
+@version: 3.25
 @include "scl.conf"
 
 # Syslog-ng configuration file, compatible with default Debian syslogd
@@ -6,8 +6,8 @@
 
 # First, set some global options.
 options { chain_hostnames(off); flush_lines(0); use_dns(no); use_fqdn(no);
-    owner("root"); group("adm"); perm(0640); stats_freq(0);
-    bad_hostname("^gconfd$");
+	  dns_cache(no); owner("root"); group("adm"); perm(0640);
+	  stats_freq(0); bad_hostname("^gconfd$");
 };
 
 ########################


### PR DESCRIPTION
Fixes https://github.com/phusion/baseimage-docker/issues/589

Applied the diffs between `syslog-ng.conf` and `/etc/syslog-ng/syslog-ng.conf` installed by `syslog-ng 3.25.1-3`.

This resolves the following warnings:

> WARNING: Configuration file format is too old, syslog-ng is running in compatibility mode. Please update it to use the syslog-ng 3.25 format at your time of convenience. To upgrade the configuration, please review the warnings about incompatible changes printed by syslog-ng, and once completed change the @version header at the top of the configuration file; config-version='3.13'

> WARNING: With use-dns(no), dns-cache() will be forced to 'no' too!;

> WARNING: log-fifo-size() works differently starting with syslog-ng 3.22 to avoid dropping flow-controlled messages when log-fifo-size() is misconfigured. From now on, log-fifo-size() only affects messages that are not flow-controlled. (Flow-controlled log paths have the flags(flow-control) option set.) To enable the new behaviour, update the @version string in your configuration and consider lowering the value of log-fifo-size().;


