### PR TITLE
CI: Drop support for i386 and ppc64le. Update to newer QEMU.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 os: linux
 
-dist: bionic
+dist: focal
 
 language: c
 
@@ -18,17 +18,17 @@ env:
     # - VERSION=${TRAVIS_TAG}
     - VERSION=${TRAVIS_BRANCH}
     - DOCKER_CLI_EXPERIMENTAL=enabled
-    - QEMU_VERSION=v4.0.0
+    - QEMU_VERSION=v6.1.0-1
 
   matrix:
     # PLATFORM = Base image architecture to be used
     # QEMU_ARCH = qemu binary to be downloaded from https://github.com/multiarch/qemu-user-static/releases
     # TAG_ARCH = Tag to be applied to the image when upload to DockerHub
-    - PLATFORM=amd64 QEMU_ARCH=i386   TAG_ARCH=386
+#    - PLATFORM=amd64 QEMU_ARCH=i386   TAG_ARCH=386
     - PLATFORM=amd64 QEMU_ARCH=amd64   TAG_ARCH=amd64
     - PLATFORM=arm64 QEMU_ARCH=aarch64 TAG_ARCH=arm64
 #     - PLATFORM=arm   QEMU_ARCH=arm     TAG_ARCH=arm
-    - PLATFORM=ppc64le   QEMU_ARCH=ppc64le     TAG_ARCH=ppc64le
+#    - PLATFORM=ppc64le   QEMU_ARCH=ppc64le     TAG_ARCH=ppc64le
 #     - PLATFORM=s390x   QEMU_ARCH=s390x     TAG_ARCH=s390x
 
 before_script:
@@ -46,7 +46,7 @@ jobs:
   include:
     - stage: deploy
       env:
-        - ARCHS="amd64 arm64 386 ppc64le"
+        - ARCHS="amd64 arm64"
       script:
         - echo $NAME:$VERSION_TAG
         - echo "$DOCKER_PASSWORD" | docker login --username "$DOCKER_USERNAME" --password-stdin


### PR DESCRIPTION
I also bumped the Travis CI distribution to use to focal which is the default.