### PR TITLE
Revert "Added retreval of ubuntu key 871920D1991BC93C to apt keyring"

### DIFF
--- a/image/prepare.sh
+++ b/image/prepare.sh
@@ -14,7 +14,6 @@ echo -n no > /etc/container_environment/INITRD
 sed -i 's/^#\s*\(deb.*main restricted\)$/\1/g' /etc/apt/sources.list
 sed -i 's/^#\s*\(deb.*universe\)$/\1/g' /etc/apt/sources.list
 sed -i 's/^#\s*\(deb.*multiverse\)$/\1/g' /etc/apt/sources.list
-apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 871920D1991BC93C
 apt-get update
 
 ## Fix some issues with APT packages.


### PR DESCRIPTION
Reverts phusion/baseimage-docker#613

This is not needed after all.