### PR TITLE
Update syslog-ng.conf for Ubuntu 22.04

### DIFF
--- a/image/services/syslog-ng/syslog-ng.conf
+++ b/image/services/syslog-ng/syslog-ng.conf
@@ -1,4 +1,4 @@
-@version: 3.25
+@version: 3.35
 @include "scl.conf"
 
 # Syslog-ng configuration file, compatible with default Debian syslogd


### PR DESCRIPTION
**Description of the change**

Updates the syslog-ng configuration file format from 3.25 to 3.35 for the version of syslog-ng installed in Ubuntu 22.04

**Benefits**

Quiets the warning when phusion/baseimage:jammy-1.0.0 boots:

```
WARNING: Configuration file format is too old, syslog-ng is running in compatibility mode. Please update it to use the syslog-ng 3.35 format at your time of convenience. To upgrade the configuration, please review the warnings about incompatible changes printed by syslog-ng, and once completed change the @version header at the top of the configuration file; config-version='3.25'
WARNING: The internal_queue_length stat counter has been renamed to internal_source.queued. The old name will be removed in future versions; config-version='3.25'
```

**Possible drawbacks**

I did not investigate whether other changes are necessary to the configuration file.