### PR TITLE
ci: Use GITHUB_OUTPUT envvar instead of set-output command

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,14 +24,14 @@ jobs:
               # Set output parameters.
               
               if [ "${{github.event_name}}" == "pull_request" ]; then
-                echo ::set-output name=push::false
+                echo "push=false" >> $GITHUB_OUTPUT
               else
-                echo ::set-output name=push::true
-                echo ::set-output name=tags::${TAGS}
-                echo ::set-output name=branch::${GIT_BRANCH}
-                echo ::set-output name=docker_image::${DOCKER_IMAGE}
+                echo "push=true" >> $GITHUB_OUTPUT
+                echo "tags=${TAGS}" >> $GITHUB_OUTPUT
+                echo "branch=${GIT_BRANCH}" >> $GITHUB_OUTPUT
+                echo "docker_image=${DOCKER_IMAGE}" >> $GITHUB_OUTPUT
               fi
-              echo ::set-output name=platforms::${PLATFORMS}
+              echo "platforms=${PLATFORMS}" >> $GITHUB_OUTPUT
 
 
           - name: Set up QEMU


### PR DESCRIPTION
`save-state` and `set-output` commands used in GitHub Actions are deprecated and [GitHub recommends using environment files](https://github.blog/changelog/2023-07-24-github-actions-update-on-save-state-and-set-output-commands/).

This PR updates the usage of `set-output` to `$GITHUB_OUTPUT`

Instructions for envvar usage from GitHub docs:

https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter


