### PR TITLE
disable e2fsprogs cron

### DIFF
--- a/image/services/cron/cron.sh
+++ b/image/services/cron/cron.sh
@@ -17,3 +17,4 @@ rm -f /etc/cron.daily/upstart
 rm -f /etc/cron.daily/dpkg
 rm -f /etc/cron.daily/password
 rm -f /etc/cron.weekly/fstrim
+rm -f /etc/cron.d/e2scrub_all


### PR DESCRIPTION
**Description of the change**

This disables a cron that would run 2 commands daily.

These commands are specific to ext filesystems, so not of use inside of the docker container.

The origin of the cron is the package `e2fsprogs`, which is a dependency of `ubuntu-minimal`.

**Benefits**

Less log output Since it will remove this daily line in the log:

`CRON[1780]: (root) CMD (test -e /run/systemd/system || SERVICE_MODE=1 /sbin/e2scrub_all -A -r)`


**Possible drawbacks**

None

**Applicable issues**

None

**Additional information**

None
