### PR TITLE
image/prepare: Check if container is actually ubuntu

### DIFF
--- a/image/prepare.sh
+++ b/image/prepare.sh
@@ -11,9 +11,12 @@ mkdir -p /etc/container_environment
 echo -n no > /etc/container_environment/INITRD
 
 ## Enable Ubuntu Universe, Multiverse, and deb-src for main.
-sed -i 's/^#\s*\(deb.*main restricted\)$/\1/g' /etc/apt/sources.list
-sed -i 's/^#\s*\(deb.*universe\)$/\1/g' /etc/apt/sources.list
-sed -i 's/^#\s*\(deb.*multiverse\)$/\1/g' /etc/apt/sources.list
+if grep -E '^ID=' /etc/os-release | grep -q ubuntu; then
+  sed -i 's/^#\s*\(deb.*main restricted\)$/\1/g' /etc/apt/sources.list
+  sed -i 's/^#\s*\(deb.*universe\)$/\1/g' /etc/apt/sources.list
+  sed -i 's/^#\s*\(deb.*multiverse\)$/\1/g' /etc/apt/sources.list
+fi
+
 apt-get update
 
 ## Fix some issues with APT packages.


### PR DESCRIPTION
**Description of the change**

This allows for building a Debian image

**Benefits**

Debian image support

**Additional information**

Build args I used:

```bash
BASE_IMAGE=debian:12 NAME=my-image-name VERSION=latest QEMU_ARCH=amd64 PLATFORM=linux/amd64 make build
```

