### PR TITLE
Update GitHub actions to newest versions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,8 +10,8 @@ jobs:
         if: "!contains(github.event.head_commit.message, '[ci-skip]')"
         steps:
           - name: Checkout
-            uses: actions/checkout@v2
-            
+            uses: actions/checkout@v4
+
           - name: Prepare
             id: prep
             run: |
@@ -35,12 +35,12 @@ jobs:
 
 
           - name: Set up QEMU
-            uses: docker/setup-qemu-action@v1
+            uses: docker/setup-qemu-action@v3
             with:
               platforms: ${{ steps.prep.outputs.platforms }}
-              
+
           - name: Login to GHCR (Github Container Registry)
-            uses: docker/login-action@v1
+            uses: docker/login-action@v3
             if: github.event_name != 'pull_request'
             with:
              registry: ghcr.io
@@ -49,22 +49,22 @@ jobs:
 
           - name: Set up Docker Buildx
             id: buildx
-            uses: docker/setup-buildx-action@v1
+            uses: docker/setup-buildx-action@v3
             with:
               install: true
               version: latest
               driver-opts: image=moby/buildkit:latest
-              
+
 
           - name: Login to Docker Hub
             if: github.event_name != 'pull_request'
-            uses: docker/login-action@v1
+            uses: docker/login-action@v3
             with:
                 username: ${{ secrets.DOCKER_USERNAME }}
                 password: ${{ secrets.DOCKER_PASSWORD }}
-              
+
           - name: Build and Push
-            uses: docker/build-push-action@v2
+            uses: docker/build-push-action@v5
             with:
               builder: ${{ steps.buildx.outputs.name }}
               context: image

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -7,7 +7,7 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v3
+      - uses: actions/stale@v9
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           stale-issue-message: 'This Issue has been automatically marked as "stale" because it has not had recent activity (for 15 days). It will be closed if no further activity occurs. Thanks for the feedback.'


### PR DESCRIPTION
**Description of the change**

These changes are required to use NodeJS 20 on GitHub.

https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/

**Benefits**

The workflows will continue to run.

**Possible drawbacks**

There might be some breaking changes in the workflows. I've tested the build workflow myself and read all change notes for the `stale` action, aiming to find any breaking changes. I did not find any that are relevant for this repo. Hence, I would assume there are currently no drawbacks.

**Applicable issues**

None

**Additional information**

None