### PR TITLE
locale-gen on Debian ignores arguments and just read from /etc/locale.gen

### DIFF
--- a/image/prepare.sh
+++ b/image/prepare.sh
@@ -50,6 +50,7 @@ case $(lsb_release -is) in
     ;;
   Debian)
     $minimal_apt_get_install locales locales-all
+    echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen
     ;;
   *)
     ;;


### PR DESCRIPTION

**Description of the change**

<!-- Describe the scope of your change - i.e. what the change does. -->
change /etc/locale.gen, add en_US.UTF-8

<!-- What benefits will be realized by the code change? -->
compatitble with building baseimage of Debian
**Possible drawbacks**

<!-- Describe any known limitations with your change -->
nothing found yet

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #

**Additional information**

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->
