### PR TITLE
Fix sshd service missing on resolute

### DIFF
--- a/image/services/sshd/sshd.sh
+++ b/image/services/sshd/sshd.sh
@@ -7,8 +7,8 @@ SSHD_BUILD_PATH=/bd_build/services/sshd
 
 ## Install the SSH server.
 $minimal_apt_get_install openssh-server
-mkdir /var/run/sshd
-mkdir /etc/service/sshd
+mkdir -p /var/run/sshd
+mkdir -p /etc/service/sshd
 touch /etc/service/sshd/down
 cp $SSHD_BUILD_PATH/sshd.runit /etc/service/sshd/run
 cp $SSHD_BUILD_PATH/sshd_config /etc/ssh/sshd_config

--- a/image/system_services.sh
+++ b/image/system_services.sh
@@ -22,10 +22,16 @@ ln -s /etc/container_environment.sh /etc/profile.d/
 $minimal_apt_get_install runit
 
 ## Install a syslog daemon and logrotate.
-[ "$DISABLE_SYSLOG" -eq 0 ] && /bd_build/services/syslog-ng/syslog-ng.sh || true
+if [ "$DISABLE_SYSLOG" -eq 0 ]; then
+    /bd_build/services/syslog-ng/syslog-ng.sh
+fi
 
 ## Install the SSH server.
-[ "$DISABLE_SSH" -eq 0 ] && /bd_build/services/sshd/sshd.sh || true
+if [ "$DISABLE_SSH" -eq 0 ]; then
+    /bd_build/services/sshd/sshd.sh
+fi
 
 ## Install cron daemon.
-[ "$DISABLE_CRON" -eq 0 ] && /bd_build/services/cron/cron.sh || true
+if [ "$DISABLE_CRON" -eq 0 ]; then
+    /bd_build/services/cron/cron.sh
+fi


### PR DESCRIPTION
The script is exiting early because of this combination:
* `set -e` is active — any non-zero exit code aborts the script immediately
* `mkdir /var/run/sshd` fails with `File exists` — the `openssh-server` package already created it during installation

I've changed mkdir to mkdir -p, so that it succeeds silently if the directory already exists.

I've also removed the `|| true` which is what was swallowing the script failures. It was introduced in https://github.com/phusion/baseimage-docker/pull/235 but the correct fix is to replace the one-liners so that the condition doesn't `exit 1`

Closes #666 