### PR TITLE
Fix prepare.sh for building on Debian base images

### DIFF
--- a/image/prepare.sh
+++ b/image/prepare.sh
@@ -50,7 +50,12 @@ $minimal_apt_get_install apt-utils
 $minimal_apt_get_install apt-transport-https ca-certificates
 
 ## Install add-apt-repository
-$minimal_apt_get_install software-properties-common
+if grep -E '^ID=' /etc/os-release | grep -q ubuntu; then
+  $minimal_apt_get_install software-properties-common
+fi
+
+## Install python3 for debian
+  $minimal_apt_get_install python3
 
 ## Upgrade all packages.
 apt-get dist-upgrade -y --no-install-recommends -o Dpkg::Options::="--force-confold"
@@ -95,11 +100,11 @@ if grep -E '^ID=' /etc/os-release | grep -q ubuntu; then
 fi
 
 ## Fix locale.
-case $(lsb_release -is) in
-  Ubuntu)
+case $(grep '^ID=' /etc/os-release | cut -d= -f2) in
+  ubuntu)
     $minimal_apt_get_install language-pack-en
     ;;
-  Debian)
+  debian)
     $minimal_apt_get_install locales locales-all
     echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen
     ;;


### PR DESCRIPTION
# Support building on Debian base images

`make build BASE_IMAGE=debian:trixie ...` currently fails. The script assumes
several things that hold for the official Ubuntu images but not for the
official Debian images. This PR makes `image/prepare.sh` work on both.

## Problems

1. **`python3` is never installed.** `/sbin/my_init` is a Python 3 script
(`#!/usr/bin/python3 -u`). The Ubuntu base images ship python3, the Debian
ones do not, so the resulting image contains `my_init` but cannot execute
it:

```
   exec /sbin/my_init: no such file or directory
   ```

(here refers to the missing interpreter, not the script.)

2. **`software-properties-common` is Ubuntu-only.** It does not exist in the
Debian Trixie repositories, so installation aborts the build:

```
   E: Unable to locate package software-properties-common
   ```

3. **`lsb_release` is not available on Debian.** The `lsb-release` package is
not part of the Debian base image, so the locale block fails to detect the
distribution.

## Changes

* Install `python3` after `apt-get update`.
* Install `software-properties-common` only on Ubuntu.
* Read the distribution from `/etc/os-release` instead of `lsb_release`. This
is the same source the script already uses earlier in the file, so no new
dependency is introduced.

## Impact on Ubuntu

None. `python3` is already present there, the `software-properties-common`
install still runs on Ubuntu, and `/etc/os-release` is part of both
distributions. Ubuntu builds behave exactly as before.

## How I tested

Built the base image on `debian:trixie` running `prepare.sh`,
`system_services.sh`, `utilities.sh` and `cleanup.sh`:

```
$ make build BASE_IMAGE=debian:trixie NAME=phusion/baseimage-debian VERSION=trixie PLATFORM=amd64
```

PS: building failed without PLATFORM=amd64, that's another bug.